### PR TITLE
Filter out cache tables when checking if drupal is installed

### DIFF
--- a/drupal8-apache/7.0/usr/local/share/drupal8/install_finalise.sh
+++ b/drupal8-apache/7.0/usr/local/share/drupal8/install_finalise.sh
@@ -25,8 +25,10 @@ set -e
 if [ "$HAS_CURRENT_TABLES" -ne 0 ]; then
   chmod u+w "$SETTINGS_DIR" || true
   mkdir -p "$SETTINGS_DIR/files/"
+  chown build:build "$SETTINGS_DIR/files/"
   as_build "echo 'y' | drush site-install lightning" "/app/docroot"
   chmod a-w "$SETTINGS_DIR"
+  chown -R www-data:www-data "$SETTINGS_DIR/files/"
 fi
 
 # Download the static assets


### PR DESCRIPTION
Avoids giving false positives, as if you visit a page on the site before the database has been installed, it creates the following tables:

```
mysql> show tables;
+--------------------+
| Tables_in_drupaldb |
+--------------------+
| cache_config       |
| cache_container    |
| cache_data         |
| cachetags          |
+--------------------+
4 rows in set (0.00 sec)
```

This stymies the drush sql-query check to show all tables.