### PR TITLE
Always create files directory.

### DIFF
--- a/drupal8-apache/7.0/usr/local/share/drupal8/install_finalise.sh
+++ b/drupal8-apache/7.0/usr/local/share/drupal8/install_finalise.sh
@@ -17,14 +17,16 @@ cd /app || exit 1;
 
 SETTINGS_DIR="/app/docroot/sites/default"
 
+chmod u+w "$SETTINGS_DIR" || true
+mkdir -p "$SETTINGS_DIR/files/"
+
 # Install a database if there isn't one yet
 CURRENT_TABLES="$(as_build "drush sql-query 'SHOW TABLES;'" /app/docroot)"
 if [ "$CURRENT_TABLES" == '' ]; then
-  chmod u+w "$SETTINGS_DIR" || true
-  mkdir -p "$SETTINGS_DIR/files/"
   as_build "echo 'y' | drush site-install lightning" "/app/docroot"
-  chmod a-w "$SETTINGS_DIR"
 fi
+
+chmod a-w "$SETTINGS_DIR"
 
 # Download the static assets
 set +e
@@ -45,7 +47,7 @@ is_nfs
 IS_NFS=$?
 set -e
 if [ "$IS_NFS" -ne 0 ]; then
-  chown -R www-data:www-data "$SETTINGS_DIR"
+  chown -R www-data:www-data "$SETTINGS_DIR/files/"
 fi
 
 if [ -f "$DIR/install_finalise_custom.sh" ]; then


### PR DESCRIPTION
Drupal8 files directory was missing on next deployment to CP.