### PR TITLE
Add supervisorctl support back into supervisord

### DIFF
--- a/ubuntu/16.04/etc/supervisor/supervisord.conf
+++ b/ubuntu/16.04/etc/supervisor/supervisord.conf
@@ -6,3 +6,15 @@ pidfile = /var/run/supervisord.pid
 
 [include]
 files = /etc/supervisor/conf.d/*.conf
+
+[supervisorctl]
+serverurl = unix:///var/run/supervisor.sock
+
+[unix_http_server]
+file = /var/run/supervisor.sock
+chmod = 0700
+username = supervisor
+password = supervisor
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface


### PR DESCRIPTION
The RPC interface is used by the unix_http_server, and supervisorctl uses the unix socket that creates.

This configuration is in the default supervisord configuration