### PR TITLE
Docker-Compose Builder

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,5 +6,7 @@ else
     DIR="$(dirname "$0")" ;
 fi ;
 
-(cd "$DIR" && docker-compose pull)
+echo "Pulling any external images:\n"
+(cd "$DIR" && grep 'external_.*:' "$DIR/docker-compose.yml" | cut -d":" -f1 | xargs docker-compose pull)
+echo "Building all images:\n"
 (cd "$DIR" && docker-compose build --force-rm)

--- a/build.sh
+++ b/build.sh
@@ -1,33 +1,10 @@
 #!/bin/bash
 
-pushd ubuntu/16.04
-docker build -t quay.io/continuouspipe/ubuntu:16.04 .
-popd
+if [ -L "$0" ] ; then
+    DIR="$(dirname "$(readlink -f "$0")")" ;
+else
+    DIR="$(dirname "$0")" ;
+fi ;
 
-pushd php-apache/7.0
-docker build -t quay.io/continuouspipe/php-apache:7.0 .
-popd
-
-pushd ez/6.x
-docker build -t quay.io/continuouspipe/ez:6.x .
-popd
-
-pushd drupal8-apache/7.0
-docker build -t quay.io/continuouspipe/drupal8-apache:7.0 .
-popd
-
-pushd mysql/5.6
-docker build -t quay.io/continuouspipe/mysql:5.6 .
-popd
-
-pushd redis/3.2
-docker build -t quay.io/continuouspipe/redis:3.2 .
-popd
-
-pushd solr/6.2
-docker build -t quay.io/continuouspipe/solr:6.2 .
-popd
-
-pushd drupal8-solr/6.2
-docker build -t quay.io/continuouspipe/drupal8-solr:6.2 .
-popd
+(cd "$DIR" && docker-compose pull)
+(cd "$DIR" && docker-compose build --force-rm)

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -xe
+
 if [ -L "$0" ] ; then
     DIR="$(dirname "$(readlink -f "$0")")" ;
 else
@@ -10,3 +12,19 @@ echo "Pulling any external images:"; echo
 (cd "$DIR" && grep 'external_.*:' "$DIR/docker-compose.yml" | cut -d":" -f1 | xargs docker-compose pull)
 echo "Building all images:"; echo
 (cd "$DIR" && docker-compose build --force-rm)
+
+read -r -p "Would you like to publish the images? [Y/n] " DO_PUBLISH
+
+if [ -z "$DO_PUBLISH" ]; then
+  DO_PUBLISH='y'
+fi
+
+DO_PUBLISH="$(echo $DO_PUBLISH | tr '[A-Z]' '[a-z]')"
+if [ "$DO_PUBLISH" = 'y' ]; then
+  echo "Pushing our images:"; echo
+  (cd "$DIR" && docker-compose push)
+else
+  echo "Not Pushing our images."; echo
+fi
+
+echo "Done!"; echo

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@ else
     DIR="$(dirname "$0")" ;
 fi ;
 
-echo "Pulling any external images:\n"
+echo "Pulling any external images:"; echo
 (cd "$DIR" && grep 'external_.*:' "$DIR/docker-compose.yml" | cut -d":" -f1 | xargs docker-compose pull)
-echo "Building all images:\n"
+echo "Building all images:"; echo
 (cd "$DIR" && docker-compose build --force-rm)

--- a/build.sh
+++ b/build.sh
@@ -19,7 +19,7 @@ if [ -z "$DO_PUBLISH" ]; then
   DO_PUBLISH='y'
 fi
 
-DO_PUBLISH="$(echo $DO_PUBLISH | tr '[A-Z]' '[a-z]')"
+DO_PUBLISH="$(echo $DO_PUBLISH | tr '[:upper:]' '[:lower:]')"
 if [ "$DO_PUBLISH" = 'y' ]; then
   echo "Pushing our images:"; echo
   (cd "$DIR" && docker-compose push)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,7 @@ services:
   varnish:
     build:
       context: ./varnish/4.0/
-    image: quay.io/continuouspipe/varnish/4.0_v1
+    image: quay.io/continuouspipe/varnish:4.0_v1
     depends_on:
       - ubuntu
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -61,6 +61,8 @@ services:
     build:
       context: ./mysql/5.6/
     image: quay.io/continuouspipe/mysql:5.6_v1
+    depends_on:
+      - external_mysql
 
   nodejs:
     build:
@@ -87,21 +89,29 @@ services:
     build:
       context: ./redis/3.2/
     image: quay.io/continuouspipe/redis:3.2_v1
+    depends_on:
+      - external_redis
 
   solr_4_10:
     build:
       context: ./solr/4.10/
     image: quay.io/continuouspipe/solr:4.10_v1
+    depends_on:
+      - external_solr_4_10
 
   solr_6_2:
     build:
       context: ./solr/6.2/
     image: quay.io/continuouspipe/solr:6.2_v1
+    depends_on:
+      - external_solr_6_2
 
   ubuntu:
     build:
       context: ./ubuntu/16.04/
     image: quay.io/continuouspipe/ubuntu:16.04_v1
+    depends_on:
+      - external_ubuntu
 
   varnish:
     build:
@@ -109,3 +119,18 @@ services:
     image: quay.io/continuouspipe/varnish/4.0_v1
     depends_on:
       - ubuntu
+
+  external_mysql:
+    image: mysql:5.6
+
+  external_redis:
+    image: redis:3.2
+
+  external_solr_4_10:
+    image: makuk66/docker-solr:4.10.4
+
+  external_solr_6_2:
+    image: solr:6.2
+
+  external_ubuntu:
+    image: ubuntu:16.04

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,111 @@
+version: '2'
+
+services:
+  drupal8_apache:
+    build:
+      context: ./drupal8-apache/7.0/
+    image: quay.io/continuouspipe/drupal8-apache:7.0_v1
+    depends_on:
+      - php_apache
+
+  drupal8_solr_4_10:
+    build:
+      context: ./drupal8-solr/4.10/
+    image: quay.io/continuouspipe/drupal8-solr:4.10_v1
+    depends_on:
+      - solr_4_10
+
+  drupal8_solr_6_2:
+    build:
+      context: ./drupal8-solr/6.2/
+    image: quay.io/continuouspipe/drupal8-solr:6.2_v1
+    depends_on:
+      - solr_6_2
+
+  drupal8_varnish:
+    build:
+      context: ./drupal8-varnish/4.0/
+    image: quay.io/continuouspipe/drupal8-varnish:4.0_v1
+    depends_on:
+      - varnish
+
+  ez:
+    build:
+      context: ./ez/6.x/
+    image: quay.io/continuouspipe/ez:6.x_v1
+    depends_on:
+      - php_apache
+
+  hem:
+    build:
+      context: ./hem/
+    image: quay.io/continuouspipe/hem:latest
+    depends_on:
+      - ubuntu
+
+  magento2_nginx:
+    build:
+      context: ./magento2-nginx/fpm-7.0/
+    image: quay.io/continuouspipe/magento2-nginx:fpm-7.0_v1
+    depends_on:
+      - php_nginx
+
+  magento2_varnish:
+    build:
+      context: ./magento2-varnish/4.0/
+    image: quay.io/continuouspipe/magento2-varnish:4.0_v1
+    depends_on:
+      - varnish
+
+  mysql:
+    build:
+      context: ./mysql/5.6/
+    image: quay.io/continuouspipe/mysql:5.6_v1
+
+  nodejs:
+    build:
+      context: ./nodejs/6.0/
+    image: quay.io/continuouspipe/nodejs:6.0_v1
+    depends_on:
+      - ubuntu
+
+  php_apache:
+    build:
+      context: ./php-apache/7.0/
+    image: quay.io/continuouspipe/php-apache:7.0_v1
+    depends_on:
+      - ubuntu
+
+  php_nginx:
+    build:
+      context: ./php-nginx/7.0/
+    image: quay.io/continuouspipe/php-nginx:7.0_v1
+    depends_on:
+      - ubuntu
+
+  redis:
+    build:
+      context: ./redis/3.2/
+    image: quay.io/continuouspipe/redis:3.2_v1
+
+  solr_4_10:
+    build:
+      context: ./solr/4.10/
+    image: quay.io/continuouspipe/solr:4.10_v1
+
+  solr_6_2:
+    build:
+      context: ./solr/6.2/
+    image: quay.io/continuouspipe/solr:6.2_v1
+
+  ubuntu:
+    build:
+      context: ./ubuntu/16.04/
+    image: quay.io/continuouspipe/ubuntu:16.04_v1
+
+  varnish:
+    build:
+      context: ./varnish/4.0/
+    image: quay.io/continuouspipe/varnish/4.0_v1
+    depends_on:
+      - ubuntu

--- a/drupal8-apache/7.0/Dockerfile
+++ b/drupal8-apache/7.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/continuouspipe/php-apache:7.0
+FROM quay.io/continuouspipe/php-apache:7.0_v1
 
 MAINTAINER "Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>"
 

--- a/drupal8-solr/4.10/Dockerfile
+++ b/drupal8-solr/4.10/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/continuouspipe/solr:4.10_v2
+FROM quay.io/continuouspipe/solr:4.10_v1
 
 MAINTAINER Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>
 

--- a/drupal8-solr/6.2/Dockerfile
+++ b/drupal8-solr/6.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/continuouspipe/solr:6.2
+FROM quay.io/continuouspipe/solr:6.2_v1
 
 MAINTAINER Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>
 

--- a/drupal8-varnish/4.0/Dockerfile
+++ b/drupal8-varnish/4.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/continuouspipe/varnish:4.0
+FROM quay.io/continuouspipe/varnish:4.0_v1
 
 MAINTAINER Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>
 

--- a/ez/6.x/Dockerfile
+++ b/ez/6.x/Dockerfile
@@ -1,3 +1,3 @@
-FROM quay.io/continuouspipe/php-apache:7.0
+FROM quay.io/continuouspipe/php-apache:7.0_v1
 
 COPY etc /etc

--- a/hem/Dockerfile
+++ b/hem/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/continuouspipe/ubuntu:16.04
+FROM quay.io/continuouspipe/ubuntu:16.04_v1
 
 MAINTAINER Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>
 

--- a/magento2-nginx/fpm-7.0/Dockerfile
+++ b/magento2-nginx/fpm-7.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/continuouspipe/php-nginx:7.0
+FROM quay.io/continuouspipe/php-nginx:7.0_v1
 
 MAINTAINER Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>
 

--- a/magento2-varnish/4.0/Dockerfile
+++ b/magento2-varnish/4.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/continuouspipe/varnish:4.0
+FROM quay.io/continuouspipe/varnish:4.0_v1
 
 MAINTAINER Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>
 

--- a/nodejs/6.0/Dockerfile
+++ b/nodejs/6.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/continuouspipe/ubuntu:16.04
+FROM quay.io/continuouspipe/ubuntu:16.04_v1
 
 MAINTAINER Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>
 

--- a/php-apache/7.0/Dockerfile
+++ b/php-apache/7.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/continuouspipe/ubuntu:16.04
+FROM quay.io/continuouspipe/ubuntu:16.04_v1
 
 RUN echo 'deb http://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages debian main' > /etc/apt/sources.list.d/tideways.list \
  && curl -sS https://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages/EEB5E8F4.gpg | apt-key add - \

--- a/php-nginx/7.0/Dockerfile
+++ b/php-nginx/7.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/continuouspipe/ubuntu:16.04
+FROM quay.io/continuouspipe/ubuntu:16.04_v1
 
 MAINTAINER Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>
 

--- a/varnish/4.0/Dockerfile
+++ b/varnish/4.0/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/continuouspipe/ubuntu:16.04
+FROM quay.io/continuouspipe/ubuntu:16.04_v1
 
 MAINTAINER Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>
 


### PR DESCRIPTION
Solves the question of dependencies for image build order, as with this you can't accidentally get the ordering wrong.

Fetches explicitly declared external images first, then builds on top of them through the dependency tree.

When adding new images, please add a config section to this docker-compose.yml