### PR TITLE
Use variables for code owner

### DIFF
--- a/drupal8-apache/7.0/usr/local/share/drupal8/development/install.sh
+++ b/drupal8-apache/7.0/usr/local/share/drupal8/development/install.sh
@@ -54,6 +54,8 @@ fi
 # Install assets
 bash "$DIR/install_assets.sh"
 
+as_code_owner "drush cache-rebuild" "/app/docroot"
+
 if [ -f "$DIR/install_custom.sh" ]; then
   bash "$DIR/install_custom.sh"
 fi

--- a/drupal8-apache/7.0/usr/local/share/drupal8/development/install_database.sh
+++ b/drupal8-apache/7.0/usr/local/share/drupal8/development/install_database.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+function database_connected() {
+  mysql -h"$DATABASE_HOST" -u"$DATABASE_USER" -p"$DATABASE_PASSWORD" -e "SELECT 1;"
+}
+
 function database_exists() {
   mysql -h"$DATABASE_HOST" -u"$DATABASE_USER" -p"$DATABASE_PASSWORD" "$DATABASE_NAME" -e "SHOW TABLES; SELECT FOUND_ROWS() > 0;" | grep -q 1
 }
@@ -11,40 +15,46 @@ if [ -f tools/assets/development/drupaldb.sql.gz ]; then
   fi
 
   set +e
+  database_connected
+  DATABASE_CONNECTED=$?
+
   database_exists
   DATABASE_EXISTS=$?
   set -e
 
-  if [ "$DATABASE_EXISTS" -ne 0 ]; then
+  if [ "$DATABASE_CONNECTED" -eq 0 ] && [ "$DATABASE_EXISTS" -ne 0 ]; then
     echo 'Create drupal database'
     echo "CREATE DATABASE IF NOT EXISTS $DATABASE_NAME ; GRANT ALL ON $DATABASE_NAME.* TO $DATABASE_USER@'%' IDENTIFIED BY '$DATABASE_PASSWORD' ; FLUSH PRIVILEGES" |  mysql -uroot -p"$DATABASE_ROOT_PASSWORD" -h"$DATABASE_HOST"
 
     echo 'zcating the drupal database dump into the database'
     zcat tools/assets/development/drupaldb.sql.gz | mysql -h"$DATABASE_HOST" -uroot -p"$DATABASE_ROOT_PASSWORD" "$DATABASE_NAME" || exit 1
   fi
-fi
-
-set +e
-database_exists
-DATABASE_EXISTS=$?
-set -e
-
-if [ "$DATABASE_EXISTS" -ne 0 ]; then
-  SETTINGS_DIR="/app/docroot/sites/default"
-
-  chmod u+w "$SETTINGS_DIR" || true
-  mkdir -p "$SETTINGS_DIR/files/"
-
-  # Install a database if there isn't one yet
+else
   set +e
-  as_code_owner "drush sql-query 'SHOW TABLES;' | grep -v cache | grep -q ''" /app/docroot
-  HAS_CURRENT_TABLES=$?
-  set -e
-  if [ "$HAS_CURRENT_TABLES" -ne 0 ] && [ -n "$DRUPAL_INSTALL_PROFILE" ]; then
-    chown "$CODE_OWNER:$CODE_GROUP" "$SETTINGS_DIR/files/"
-    as_code_owner "echo 'y' | drush site-install $DRUPAL_INSTALL_PROFILE" "/app/docroot"
-    chown -R "$APP_USER:$APP_GROUP" "$SETTINGS_DIR/files/"
-  fi
+  database_connected
+  DATABASE_CONNECTED=$?
 
-  chmod a-w "$SETTINGS_DIR"
+  database_exists
+  DATABASE_EXISTS=$?
+  set -e
+
+  if [ "$DATABASE_CONNECTED" -eq 0 ] && [ "$DATABASE_EXISTS" -ne 0 ]; then
+    SETTINGS_DIR="/app/docroot/sites/default"
+
+    chmod u+w "$SETTINGS_DIR" || true
+    mkdir -p "$SETTINGS_DIR/files/"
+
+    # Install a database if there isn't one yet
+    set +e
+    as_code_owner "drush sql-query 'SHOW TABLES;' | grep -v cache | grep -q ''" /app/docroot
+    HAS_CURRENT_TABLES=$?
+    set -e
+    if [ "$HAS_CURRENT_TABLES" -ne 0 ] && [ -n "$DRUPAL_INSTALL_PROFILE" ]; then
+      chown "$CODE_OWNER:$CODE_GROUP" "$SETTINGS_DIR/files/"
+      as_code_owner "echo 'y' | drush site-install $DRUPAL_INSTALL_PROFILE" "/app/docroot"
+      chown -R "$APP_USER:$APP_GROUP" "$SETTINGS_DIR/files/"
+    fi
+
+    chmod a-w "$SETTINGS_DIR"
+  fi
 fi

--- a/drupal8-apache/7.0/usr/local/share/drupal8/install.sh
+++ b/drupal8-apache/7.0/usr/local/share/drupal8/install.sh
@@ -5,22 +5,14 @@ if [ -L "$0" ] ; then
     DIR="$(dirname "$(readlink -f "$0")")" ;
 else
     DIR="$(dirname "$0")" ;
-fi ;
+fi
 
 source /usr/local/share/bootstrap/common_functions.sh
+source /usr/local/share/php/common_functions.sh
 
 cd /app || exit 1;
 
-if [ ! -d "/app/vendor" ] || [ ! -f "/app/vendor/autoload.php" ]; then
-  if [ -n "$GITHUB_TOKEN" ]; then
-    as_build "composer config github-oauth.github.com '$GITHUB_TOKEN'"
-  fi
-
-  as_build "composer install --optimize-autoloader --no-interaction"
-  as_build "composer clear-cache"
-
-  chmod -R go-w vendor
-fi
+run_composer
 
 cd /app/docroot || exit 1;
 

--- a/drupal8-apache/7.0/usr/local/share/drupal8/install_finalise.sh
+++ b/drupal8-apache/7.0/usr/local/share/drupal8/install_finalise.sh
@@ -21,13 +21,13 @@ mkdir -p "$SETTINGS_DIR/files/"
 
 # Install a database if there isn't one yet
 set +e
-as_build "drush sql-query 'SHOW TABLES;' | grep -v cache | grep -q ''" /app/docroot
+as_code_owner "drush sql-query 'SHOW TABLES;' | grep -v cache | grep -q ''" /app/docroot
 HAS_CURRENT_TABLES=$?
 set -e
 if [ "$HAS_CURRENT_TABLES" -ne 0 ] && [ -n "$DRUPAL_INSTALL_PROFILE" ]; then
-  chown build:build "$SETTINGS_DIR/files/"
-  as_build "echo 'y' | drush site-install lightning" "/app/docroot"
-  chown -R www-data:www-data "$SETTINGS_DIR/files/"
+  chown "$CODE_OWNER:$CODE_GROUP" "$SETTINGS_DIR/files/"
+  as_code_owner "echo 'y' | drush site-install lightning" "/app/docroot"
+  chown -R "$APP_USER:$APP_GROUP" "$SETTINGS_DIR/files/"
 fi
 
 chmod a-w "$SETTINGS_DIR"
@@ -51,10 +51,10 @@ is_nfs
 IS_NFS=$?
 set -e
 if [ "$IS_NFS" -ne 0 ]; then
-  chown -R www-data:www-data "$SETTINGS_DIR/files/"
+  chown -R "$APP_USER:$APP_GROUP" "$SETTINGS_DIR/files/"
 fi
 
-as_build "drush cache-rebuild" "/app/docroot"
+as_code_owner "drush cache-rebuild" "/app/docroot"
 
 if [ -f "$DIR/install_finalise_custom.sh" ]; then
   bash "$DIR/install_finalise_custom.sh"

--- a/drupal8-apache/7.0/usr/local/share/drupal8/install_finalise.sh
+++ b/drupal8-apache/7.0/usr/local/share/drupal8/install_finalise.sh
@@ -16,22 +16,6 @@ cd /app || exit 1;
 
 SETTINGS_DIR="/app/docroot/sites/default"
 
-chmod u+w "$SETTINGS_DIR" || true
-mkdir -p "$SETTINGS_DIR/files/"
-
-# Install a database if there isn't one yet
-set +e
-as_code_owner "drush sql-query 'SHOW TABLES;' | grep -v cache | grep -q ''" /app/docroot
-HAS_CURRENT_TABLES=$?
-set -e
-if [ "$HAS_CURRENT_TABLES" -ne 0 ] && [ -n "$DRUPAL_INSTALL_PROFILE" ]; then
-  chown "$CODE_OWNER:$CODE_GROUP" "$SETTINGS_DIR/files/"
-  as_code_owner "echo 'y' | drush site-install $DRUPAL_INSTALL_PROFILE" "/app/docroot"
-  chown -R "$APP_USER:$APP_GROUP" "$SETTINGS_DIR/files/"
-fi
-
-chmod a-w "$SETTINGS_DIR"
-
 # Download the static assets
 set +e
 is_hem_project
@@ -50,7 +34,7 @@ set +e
 is_nfs
 IS_NFS=$?
 set -e
-if [ "$IS_NFS" -ne 0 ]; then
+if [ "$IS_NFS" -ne 0 ] && [ -d "$SETTINGS_DIR/files/" ]; then
   chown -R "$APP_USER:$APP_GROUP" "$SETTINGS_DIR/files/"
 fi
 

--- a/drupal8-apache/7.0/usr/local/share/drupal8/install_finalise.sh
+++ b/drupal8-apache/7.0/usr/local/share/drupal8/install_finalise.sh
@@ -38,8 +38,6 @@ if [ "$IS_NFS" -ne 0 ] && [ -d "$SETTINGS_DIR/files/" ]; then
   chown -R "$APP_USER:$APP_GROUP" "$SETTINGS_DIR/files/"
 fi
 
-as_code_owner "drush cache-rebuild" "/app/docroot"
-
 if [ -f "$DIR/install_finalise_custom.sh" ]; then
   bash "$DIR/install_finalise_custom.sh"
 fi

--- a/drupal8-apache/7.0/usr/local/share/drupal8/install_finalise.sh
+++ b/drupal8-apache/7.0/usr/local/share/drupal8/install_finalise.sh
@@ -20,8 +20,10 @@ chmod u+w "$SETTINGS_DIR" || true
 mkdir -p "$SETTINGS_DIR/files/"
 
 # Install a database if there isn't one yet
+set +e
 as_build "drush sql-query 'SHOW TABLES;' | grep -v cache | grep -q ''" /app/docroot
 HAS_CURRENT_TABLES=$?
+set -e
 if [ "$HAS_CURRENT_TABLES" -ne 0 ] && [ -n "$DRUPAL_INSTALL_PROFILE" ]; then
   as_build "echo 'y' | drush site-install '$DRUPAL_INSTALL_PROFILE'" "/app/docroot"
 fi

--- a/drupal8-apache/7.0/usr/local/share/drupal8/install_finalise.sh
+++ b/drupal8-apache/7.0/usr/local/share/drupal8/install_finalise.sh
@@ -25,7 +25,9 @@ as_build "drush sql-query 'SHOW TABLES;' | grep -v cache | grep -q ''" /app/docr
 HAS_CURRENT_TABLES=$?
 set -e
 if [ "$HAS_CURRENT_TABLES" -ne 0 ] && [ -n "$DRUPAL_INSTALL_PROFILE" ]; then
-  as_build "echo 'y' | drush site-install '$DRUPAL_INSTALL_PROFILE'" "/app/docroot"
+  chown build:build "$SETTINGS_DIR/files/"
+  as_build "echo 'y' | drush site-install lightning" "/app/docroot"
+  chown -R www-data:www-data "$SETTINGS_DIR/files/"
 fi
 
 chmod a-w "$SETTINGS_DIR"

--- a/drupal8-apache/7.0/usr/local/share/drupal8/install_finalise.sh
+++ b/drupal8-apache/7.0/usr/local/share/drupal8/install_finalise.sh
@@ -26,7 +26,7 @@ HAS_CURRENT_TABLES=$?
 set -e
 if [ "$HAS_CURRENT_TABLES" -ne 0 ] && [ -n "$DRUPAL_INSTALL_PROFILE" ]; then
   chown "$CODE_OWNER:$CODE_GROUP" "$SETTINGS_DIR/files/"
-  as_code_owner "echo 'y' | drush site-install lightning" "/app/docroot"
+  as_code_owner "echo 'y' | drush site-install $DRUPAL_INSTALL_PROFILE" "/app/docroot"
   chown -R "$APP_USER:$APP_GROUP" "$SETTINGS_DIR/files/"
 fi
 

--- a/drupal8-apache/7.0/usr/local/share/drupal8/install_finalise.sh
+++ b/drupal8-apache/7.0/usr/local/share/drupal8/install_finalise.sh
@@ -20,8 +20,9 @@ chmod u+w "$SETTINGS_DIR" || true
 mkdir -p "$SETTINGS_DIR/files/"
 
 # Install a database if there isn't one yet
-CURRENT_TABLES="$(as_build "drush sql-query 'SHOW TABLES;'" /app/docroot)"
-if [ "$CURRENT_TABLES" == '' ] && [ -n "$DRUPAL_INSTALL_PROFILE" ]; then
+as_build "drush sql-query 'SHOW TABLES;' | grep -v cache | grep -q ''" /app/docroot
+HAS_CURRENT_TABLES=$?
+if [ "$HAS_CURRENT_TABLES" -ne 0 ] && [ -n "$DRUPAL_INSTALL_PROFILE" ]; then
   as_build "echo 'y' | drush site-install '$DRUPAL_INSTALL_PROFILE'" "/app/docroot"
 fi
 

--- a/drupal8-apache/7.0/usr/local/share/env/custom_env_variables
+++ b/drupal8-apache/7.0/usr/local/share/env/custom_env_variables
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 export DRUPAL_INSTALL_PROFILE=${DRUPAL_INSTALL_PROFILE:-lightning}
+export FORCE_DATABASE_DROP=${FORCE_DATABASE_DROP:-false}

--- a/php-apache/7.0/usr/local/share/php/common_functions.sh
+++ b/php-apache/7.0/usr/local/share/php/common_functions.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 source /usr/local/share/bootstrap/common_functions.sh
 

--- a/php-apache/7.0/usr/local/share/php/common_functions.sh
+++ b/php-apache/7.0/usr/local/share/php/common_functions.sh
@@ -11,15 +11,16 @@ run_composer() {
   if [ ! -d "/app/vendor" ] || [ ! -f "/app/vendor/autoload.php" ]; then
     mkdir -p /app/vendor
     if [ "$IS_NFS" -ne 0 ]; then
-      chown build:build /app/vendor
+      chown "$CODE_OWNER":"$CODE_GROUP" /app/vendor
     fi
 
     if [ -n "$GITHUB_TOKEN" ]; then
-      as_build "composer config github-oauth.github.com '$GITHUB_TOKEN'"
+      as_code_owner "composer global config github-oauth.github.com '$GITHUB_TOKEN'"
     fi
 
-    as_build "composer install --no-interaction --optimize-autoloader"
-    as_build "composer clear-cache"
+    as_code_owner "composer install --no-interaction --optimize-autoloader"
+    rm -rf /home/build/.composer/cache/
+    as_code_owner "composer clear-cache"
 
     if [ "$IS_NFS" -ne 0 ]; then
       chown -R "$CODE_OWNER:$APP_GROUP" /app/vendor

--- a/php-apache/7.0/usr/local/share/php/common_functions.sh
+++ b/php-apache/7.0/usr/local/share/php/common_functions.sh
@@ -1,0 +1,30 @@
+#/bin/bash
+
+source /usr/local/share/bootstrap/common_functions.sh
+
+run_composer() {
+  set +e
+  is_nfs
+  IS_NFS=$?
+  set -e
+
+  if [ ! -d "/app/vendor" ] || [ ! -f "/app/vendor/autoload.php" ]; then
+    mkdir -p /app/vendor
+    if [ "$IS_NFS" -ne 0 ]; then
+      chown build:build /app/vendor
+    fi
+
+    if [ -n "$GITHUB_TOKEN" ]; then
+      as_build "composer config github-oauth.github.com '$GITHUB_TOKEN'"
+    fi
+
+    as_build "composer install --no-interaction --optimize-autoloader"
+    as_build "composer clear-cache"
+
+    if [ "$IS_NFS" -ne 0 ]; then
+      chown -R "$CODE_OWNER:$APP_GROUP" /app/vendor
+    fi
+
+    chmod -R go-w /app/vendor
+  fi
+}

--- a/php-nginx/7.0/usr/local/share/php/common_functions.sh
+++ b/php-nginx/7.0/usr/local/share/php/common_functions.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 source /usr/local/share/bootstrap/common_functions.sh
 

--- a/php-nginx/7.0/usr/local/share/php/common_functions.sh
+++ b/php-nginx/7.0/usr/local/share/php/common_functions.sh
@@ -1,0 +1,30 @@
+#/bin/bash
+
+source /usr/local/share/bootstrap/common_functions.sh
+
+run_composer() {
+  set +e
+  is_nfs
+  IS_NFS=$?
+  set -e
+
+  if [ ! -d "/app/vendor" ] || [ ! -f "/app/vendor/autoload.php" ]; then
+    mkdir -p /app/vendor
+    if [ "$IS_NFS" -ne 0 ]; then
+      chown build:build /app/vendor
+    fi
+
+    if [ -n "$GITHUB_TOKEN" ]; then
+      as_build "composer config github-oauth.github.com '$GITHUB_TOKEN'"
+    fi
+
+    as_build "composer install --no-interaction --optimize-autoloader"
+    as_build "composer clear-cache"
+
+    if [ "$IS_NFS" -ne 0 ]; then
+      chown -R "$CODE_OWNER:$APP_GROUP" /app/vendor
+    fi
+
+    chmod -R go-w /app/vendor
+  fi
+}

--- a/php-nginx/7.0/usr/local/share/php/common_functions.sh
+++ b/php-nginx/7.0/usr/local/share/php/common_functions.sh
@@ -11,15 +11,15 @@ run_composer() {
   if [ ! -d "/app/vendor" ] || [ ! -f "/app/vendor/autoload.php" ]; then
     mkdir -p /app/vendor
     if [ "$IS_NFS" -ne 0 ]; then
-      chown build:build /app/vendor
+      chown "$CODE_OWNER":"$CODE_GROUP" /app/vendor
     fi
 
     if [ -n "$GITHUB_TOKEN" ]; then
-      as_build "composer config github-oauth.github.com '$GITHUB_TOKEN'"
+      as_code_owner "composer global config github-oauth.github.com '$GITHUB_TOKEN'"
     fi
 
-    as_build "composer install --no-interaction --optimize-autoloader"
-    as_build "composer clear-cache"
+    as_code_owner "composer install --no-interaction --optimize-autoloader"
+    as_code_owner "composer clear-cache"
 
     if [ "$IS_NFS" -ne 0 ]; then
       chown -R "$CODE_OWNER:$APP_GROUP" /app/vendor

--- a/php-nginx/7.0/usr/local/share/php/common_functions.sh
+++ b/php-nginx/7.0/usr/local/share/php/common_functions.sh
@@ -19,6 +19,7 @@ run_composer() {
     fi
 
     as_code_owner "composer install --no-interaction --optimize-autoloader"
+    rm -rf /home/build/.composer/cache/
     as_code_owner "composer clear-cache"
 
     if [ "$IS_NFS" -ne 0 ]; then

--- a/symfony/3-apache/usr/local/share/symfony/install.sh
+++ b/symfony/3-apache/usr/local/share/symfony/install.sh
@@ -3,6 +3,7 @@
 set -xe
 
 source /usr/local/share/bootstrap/common_functions.sh
+source /usr/local/share/php/common_functions.sh
 
 mkdir -p /app/var
 
@@ -22,8 +23,4 @@ else
   chmod -R a+rw /app/var
 fi
 
-if [ ! -d "/app/vendor" ] || [ ! -f "/app/vendor/autoload.php" ]; then
-  as_build "composer install --no-interaction --optimize-autoloader"
-fi
-
-chmod -R go-w /app/vendor
+run_composer

--- a/symfony/3-apache/usr/local/share/symfony/install.sh
+++ b/symfony/3-apache/usr/local/share/symfony/install.sh
@@ -15,8 +15,8 @@ set -e
 
 if [ "$IS_NFS" -ne 0 ]; then
   # Fix permissions so the web server user can write to /app/var for symfony cache files
-  chown -R build:build /app
-  chown -R build:www-data /app/var
+  chown -R "$CODE_OWNER:$CODE_GROUP" /app
+  chown -R "$CODE_OWNER:$APP_GROUP" /app/var
   chmod -R ug+rw,o-rw /app/var
 else
   chmod -R a+rw /app/var


### PR DESCRIPTION
As the code owner can now be a dynamically named user, always running as the build user would not make sense.

Instead, use the new functionality introduced in #48 to chown files to the new code user and run commands as them as well.

Incorporates #47