### PR TITLE
Extract the running of confd to a separate script

### DIFF
--- a/drupal8-apache/7.0/usr/local/share/drupal8/development/install.sh
+++ b/drupal8-apache/7.0/usr/local/share/drupal8/development/install.sh
@@ -1,18 +1,11 @@
 #!/bin/bash
 set -xe
 
-# Initialisation - Declare custom environment variables
-source /usr/local/share/env/custom_env_variables
-
-# Initialisation - Declare default environment variables
-source /usr/local/share/env/default_env_variables
-
+# Ensure confd can create the hem config in the build user's home directory
 mkdir -p /home/build/.hem/gems/ && chown -R build:build /home/build/.hem/
 
-set +e
-# Initialisation - Templating
-confd -onetime -backend env
-set -e
+# Ensure the settings file exists by running confd before continuing
+source /usr/local/share/bootstrap/run_confd.sh
 
 # install DB and assets
 if [ -L "$0" ] ; then

--- a/drupal8-apache/7.0/usr/local/share/drupal8/development/install.sh
+++ b/drupal8-apache/7.0/usr/local/share/drupal8/development/install.sh
@@ -4,7 +4,8 @@ set -xe
 # Ensure confd can create the hem config in the build user's home directory
 mkdir -p /home/build/.hem/gems/ && chown -R build:build /home/build/.hem/
 
-# Ensure the settings file exists by running confd before continuing
+# Ensure the hem and drupal settings files exists by running confd before continuing
+source /usr/local/share/bootstrap/setup.sh
 source /usr/local/share/bootstrap/run_confd.sh
 
 # install DB and assets

--- a/ubuntu/16.04/usr/local/bin/supervisor_start
+++ b/ubuntu/16.04/usr/local/bin/supervisor_start
@@ -1,17 +1,8 @@
 #!/bin/bash
 set -xe
 
-# Initialisation - Declare custom environment variables
-source /usr/local/share/env/custom_env_variables
-
-# Initialisation - Declare default environment variables
-source /usr/local/share/env/default_env_variables
-
-# Initialisation - create a user to match the mountpoint's settings if told to
-source /usr/local/share/bootstrap/trigger_update_permissions.sh
-
-# Initialisation - Templating
-confd -onetime -backend env
+# Initalisation - Run confd after declaring environment variables
+source /usr/local/share/bootstrap/run_confd.sh
 
 # Initialisation - Runtime installation tasks
 source /usr/local/bin/supervisor_custom_start

--- a/ubuntu/16.04/usr/local/bin/supervisor_start
+++ b/ubuntu/16.04/usr/local/bin/supervisor_start
@@ -1,7 +1,10 @@
 #!/bin/bash
 set -xe
 
-# Initalisation - Run confd after declaring environment variables
+# Initialisation - Declare variables and run pre-templating steps.
+source /usr/local/share/bootstrap/setup.sh
+
+# Initalisation - Run templating (confd) after declaring environment variables
 source /usr/local/share/bootstrap/run_confd.sh
 
 # Initialisation - Runtime installation tasks

--- a/ubuntu/16.04/usr/local/share/bootstrap/run_confd.sh
+++ b/ubuntu/16.04/usr/local/share/bootstrap/run_confd.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Initialisation - Declare custom environment variables
+source /usr/local/share/env/custom_env_variables
+
+# Initialisation - Declare default environment variables
+source /usr/local/share/env/default_env_variables
+
+# Initialisation - Declare variables used by scripts in the ubuntu base image
+# to avoid undeclared variables!
+source /usr/local/share/env/bootstrap_env_variables
+
+# Initialisation - Pre templating
+source /usr/local/share/bootstrap/pre_templating.sh
+
+# Initialisation - create a user to match the mountpoint's settings if told to
+source /usr/local/share/bootstrap/trigger_update_permissions.sh
+
+# Initialisation - Templating
+confd -onetime -backend env

--- a/ubuntu/16.04/usr/local/share/bootstrap/run_confd.sh
+++ b/ubuntu/16.04/usr/local/share/bootstrap/run_confd.sh
@@ -1,5 +1,3 @@
 #!/bin/bash
 
-source /usr/local/share/bootstrap/setup.sh
-
 do_confd

--- a/ubuntu/16.04/usr/local/share/bootstrap/run_confd.sh
+++ b/ubuntu/16.04/usr/local/share/bootstrap/run_confd.sh
@@ -1,20 +1,5 @@
 #!/bin/bash
 
-# Initialisation - Declare custom environment variables
-source /usr/local/share/env/custom_env_variables
+source /usr/local/share/bootstrap/setup.sh
 
-# Initialisation - Declare default environment variables
-source /usr/local/share/env/default_env_variables
-
-# Initialisation - Declare variables used by scripts in the ubuntu base image
-# to avoid undeclared variables!
-source /usr/local/share/env/bootstrap_env_variables
-
-# Initialisation - Pre templating
-source /usr/local/share/bootstrap/pre_templating.sh
-
-# Initialisation - create a user to match the mountpoint's settings if told to
-source /usr/local/share/bootstrap/trigger_update_permissions.sh
-
-# Initialisation - Templating
-confd -onetime -backend env
+do_confd

--- a/ubuntu/16.04/usr/local/share/bootstrap/setup.sh
+++ b/ubuntu/16.04/usr/local/share/bootstrap/setup.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Initialisation - Declare custom environment variables
+source /usr/local/share/env/custom_env_variables
+
+# Initialisation - Declare default environment variables
+source /usr/local/share/env/default_env_variables
+
+# Initialisation - Declare variables used by scripts in the ubuntu base image
+# to avoid undeclared variables!
+source /usr/local/share/env/bootstrap_env_variables
+
+# Initialisation - Pre templating
+source /usr/local/share/bootstrap/pre_templating.sh
+
+# Initialisation - create a user to match the mountpoint's settings if told to
+source /usr/local/share/bootstrap/trigger_update_permissions.sh
+
+function do_confd() {
+  # Initialisation - Templating
+  confd -onetime -backend env
+}


### PR DESCRIPTION
This is so we can re-use it in one-off scripts like drupal8's development install, which requires the correct database variables and user setup.