### PR TITLE
Fix drupal8 config syntax.

### DIFF
--- a/drupal8-apache/7.0/etc/confd/templates/drupal/settings.php.tmpl
+++ b/drupal8-apache/7.0/etc/confd/templates/drupal/settings.php.tmpl
@@ -2,14 +2,14 @@
 /*
  * Variables declared via environment variables go here!
  */
-$settings['hash_salt'] = $_ENV['DRUPAL_HASH_SALT']';
+$settings['hash_salt'] = $_ENV['DRUPAL_HASH_SALT'];
 $databases['default']['default'] = array (
-    'database' => $_ENV['DRUPAL_DATABASE_NAME']',
-    'username' => $_ENV['DRUPAL_DATABASE_USERNAME']',
-    'password' => $_ENV['DRUPAL_DATABASE_PASSWORD']',
-    'prefix' => $_ENV['DRUPAL_DATABASE_PREFIX']',
-    'host' => $_ENV['DRUPAL_DATABASE_HOST']',
-    'port' => $_ENV['DRUPAL_DATABASE_PORT']',
+    'database' => $_ENV['DRUPAL_DATABASE_NAME'],
+    'username' => $_ENV['DRUPAL_DATABASE_USERNAME'],
+    'password' => $_ENV['DRUPAL_DATABASE_PASSWORD'],
+    'prefix' => $_ENV['DRUPAL_DATABASE_PREFIX'],
+    'host' => $_ENV['DRUPAL_DATABASE_HOST'],
+    'port' => $_ENV['DRUPAL_DATABASE_PORT'],
     'namespace' => 'Drupal\\Core\\Database\\Driver\\mysql',
     'driver' => 'mysql',
 );


### PR DESCRIPTION
Oops! Extra `'` at the end of the lines.