### PR TITLE
Switch to sudo and preserve the environment variables

### DIFF
--- a/ubuntu/16.04/usr/local/share/bootstrap/common_functions.sh
+++ b/ubuntu/16.04/usr/local/share/bootstrap/common_functions.sh
@@ -14,7 +14,7 @@ as_user() {
     USER='build';
   fi
 
-  sudo -u "$USER" -E /bin/bash -c "cd '$WORKING_DIR'; $COMMAND"
+  sudo -u "$USER" -E HOME="$(getent passwd "$USER" | cut -d: -f 6)" /bin/bash -c "cd '$WORKING_DIR'; $COMMAND"
 }
 
 as_build() {

--- a/ubuntu/16.04/usr/local/share/bootstrap/common_functions.sh
+++ b/ubuntu/16.04/usr/local/share/bootstrap/common_functions.sh
@@ -14,7 +14,7 @@ as_user() {
     USER='build';
   fi
 
-  su -l "$USER" -c "cd '$WORKING_DIR'; $COMMAND"
+  sudo -u "$USER" -E /bin/bash -c "cd '$WORKING_DIR'; $COMMAND"
 }
 
 as_build() {


### PR DESCRIPTION
Environment variables from outside the container were not persisting across the user change.

Switching to sudo instead of su allows us to run commands as system accounts like www-data too.