### PR TITLE
Allow containers without custom supervisor scripts to start.

### DIFF
--- a/ubuntu/16.04/usr/local/bin/supervisor_start
+++ b/ubuntu/16.04/usr/local/bin/supervisor_start
@@ -8,10 +8,14 @@ source /usr/local/share/bootstrap/setup.sh
 source /usr/local/share/bootstrap/run_confd.sh
 
 # Initialisation - Runtime installation tasks
-for file in /usr/local/bin/supervisor_custom_start-*; do
-  # shellcheck source=/dev/null
-  source "${file}"
-done
+shopt -s nullglob
+set -- /usr/local/bin/supervisor_custom_start-*
+if [ "$#" -gt 0 ]; then
+  for file in "$@"; do
+    # shellcheck source=/dev/null
+    source "${file}"
+  done
+fi
 
 source /usr/local/bin/supervisor_custom_start
 


### PR DESCRIPTION
Due to `set -xe`, the following happens if there are no files to include:
```
memcached_1     | 2016-12-17T20:41:25.959175919Z + for file in '/usr/local/bin/supervisor_custom_start-*'
memcached_1     | 2016-12-17T20:41:25.959414661Z + source '/usr/local/bin/supervisor_custom_start-*'
memcached_1     | 2016-12-17T20:41:25.959491594Z /usr/local/bin/supervisor_start: line 13: /usr/local/bin/supervisor_custom_start-*: No such file or directory
```

This commit adds some checks surrounding if files exist or not.