### PR TITLE
Fix socket path to be /run/php7.0-fpm.sock rather than /run/php/php7.0-fpm.sock

### DIFF
--- a/php-nginx/etc/confd/templates/nginx/site_phpfpm.conf.tmpl
+++ b/php-nginx/etc/confd/templates/nginx/site_phpfpm.conf.tmpl
@@ -1,5 +1,5 @@
     location ~ \.php(/|$) {
-        fastcgi_pass unix:/run/php/php{{ getenv "PHP_VERSION" }}-fpm.sock;
+        fastcgi_pass unix:/run/php{{ getenv "PHP_VERSION" }}-fpm.sock;
         fastcgi_split_path_info ^(.+\.php)(/.*)$;
         include fastcgi_params;
         fastcgi_param HTTPS $custom_https if_not_empty;


### PR DESCRIPTION
If kept in /run/php, an extra mkdir for /run/php is required before launching.