### PR TITLE
Remove http2 from port 80

### DIFF
--- a/php-nginx/etc/confd/templates/nginx/site.conf.tmpl
+++ b/php-nginx/etc/confd/templates/nginx/site.conf.tmpl
@@ -1,6 +1,6 @@
 server {
     server_name _;
-    listen {{ getenv "WEB_HTTP_PORT" }} default_server http2;
+    listen {{ getenv "WEB_HTTP_PORT" }} default_server;
 {{ if eq "true" (getenv "WEB_HTTPS") }}
 {{ if ne "true" (getenv "WEB_HTTP") }}
 

--- a/php-nginx/etc/confd/templates/nginx/site.conf.tmpl
+++ b/php-nginx/etc/confd/templates/nginx/site.conf.tmpl
@@ -12,10 +12,13 @@ server {
     server_name _;
 {{ end }}
 {{ if eq "true" (getenv "WEB_HTTPS_OFFLOADED") }}
-    listen {{ getenv "WEB_HTTPS_PORT" }} default_server http2;{{ else }}
+    listen {{ getenv "WEB_HTTPS_PORT" }} default_server http2;
+{{ else }}
     listen {{ getenv "WEB_HTTPS_PORT" }} default_server ssl http2;
     ssl_certificate {{ getenv "WEB_SSL_FULLCHAIN" }};
-    ssl_certificate_key {{ getenv "WEB_SSL_PRIVKEY" }};{{ end }}{{ end }}
+    ssl_certificate_key {{ getenv "WEB_SSL_PRIVKEY" }};
+{{ end }}
+{{ end }}
 
     include /etc/nginx/sites-available/default-*.conf;
 

--- a/php-nginx/etc/confd/templates/nginx/site.conf.tmpl
+++ b/php-nginx/etc/confd/templates/nginx/site.conf.tmpl
@@ -12,13 +12,10 @@ server {
     server_name _;
 {{ end }}
 {{ if eq "true" (getenv "WEB_HTTPS_OFFLOADED") }}
-    listen {{ getenv "WEB_HTTPS_PORT" }} default_server http2;
-{{ else }}
+    listen {{ getenv "WEB_HTTPS_PORT" }} default_server http2;{{ else }}
     listen {{ getenv "WEB_HTTPS_PORT" }} default_server ssl http2;
     ssl_certificate {{ getenv "WEB_SSL_FULLCHAIN" }};
-    ssl_certificate_key {{ getenv "WEB_SSL_PRIVKEY" }};
-{{ end }}
-{{ end }}
+    ssl_certificate_key {{ getenv "WEB_SSL_PRIVKEY" }};{{ end }}{{ end }}
 
     include /etc/nginx/sites-available/default-*.conf;
 


### PR DESCRIPTION
Accessing http was causing a binary download due to a http2 handshake trying to occur.