### PR TITLE
Pass error logs from php-fpm workers to their master to output

### DIFF
--- a/php-nginx/etc/confd/templates/php-fpm/pool.conf.tmpl
+++ b/php-nginx/etc/confd/templates/php-fpm/pool.conf.tmpl
@@ -2,6 +2,8 @@
 user = {{ getenv "APP_USER" }}
 group = {{ getenv "APP_GROUP" }}
 
+catch_workers_output = yes
+
 listen = /run/php{{ getenv "PHP_VERSION" }}-fpm.sock
 
 listen.owner = www-data
@@ -18,5 +20,5 @@ php_value[date.timezone] = {{ getenv "PHP_TIMEZONE" }}
 php_value[memory_limit] = {{ getenv "PHP_MEMORY_LIMIT" }}
 
 php_admin_value[display_errors] = Off
-php_admin_value[error_log] = /dev/stdout
+php_admin_value[error_log] = /dev/stderr
 php_admin_flag[log_errors] = on


### PR DESCRIPTION
Workers stdout/err get piped to /dev/null by default