### PR TITLE
Chown to build user before composer runs

### DIFF
--- a/php-apache/README.md
+++ b/php-apache/README.md
@@ -67,6 +67,7 @@ This base image adds the following bash functions:
 function | description | executed on
 --- | --- | ---
 do_composer | Runs composer install in /app if it's not been run yet | do_build, do_development_start
+do_build_permissions | Ensures that /app is owned by the build user and not www-data or root, for security and ability to run composer as a non-root user | do_build, do_development_start
 
 These functions can be triggered via the /usr/local/bin/container command, dropping off the "do_" part. e.g:
 

--- a/php-apache/usr/local/share/container/baseimage-20.sh
+++ b/php-apache/usr/local/share/container/baseimage-20.sh
@@ -5,11 +5,13 @@ source /usr/local/share/php/common_functions.sh
 alias_function do_build do_php_apache_build_inner
 do_build() {
   do_php_apache_build_inner
+  do_build_permissions
   do_composer
 }
 
 alias_function do_development_start do_php_apache_development_start_inner
 do_development_start() {
   do_php_apache_development_start_inner
+  do_build_permissions
   do_composer
 }

--- a/php-apache/usr/local/share/php/common_functions.sh
+++ b/php-apache/usr/local/share/php/common_functions.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+do_build_permissions() {
+  if [ "$IS_NFS" -ne 0 ]; then
+    setfacl -R -m "d:u:$CODE_OWNER:rwX" -m "u:$CODE_OWNER:rwX" /app/
+  else
+    chown -R "$CODE_OWNER:$CODE_GROUP" /app/
+  fi
+}
+
 run_composer() {
   if [ ! -d "/app/vendor" ] || [ ! -f "/app/vendor/autoload.php" ]; then
     mkdir -p /app/vendor

--- a/php-nginx/README.md
+++ b/php-nginx/README.md
@@ -150,6 +150,7 @@ function | description | executed on
 do_composer | Runs composer install in /app if it's not been run yet | do_build, do_development_start
 do_nginx | Runs nginx-related setup scripts | do_start
 do_https_certificates | Ensures there are [HTTPS certificates](#ssl-certificateskey) | do_nginx
+do_build_permissions | Ensures that /app is owned by the build user and not www-data or root, for security and ability to run composer as a non-root user | do_build, do_development_start
 
 These functions can be triggered via the /usr/local/bin/container command, dropping off the "do_" part. e.g:
 

--- a/php-nginx/usr/local/share/container/baseimage-20.sh
+++ b/php-nginx/usr/local/share/container/baseimage-20.sh
@@ -6,6 +6,7 @@ source /usr/local/share/php/nginx_functions.sh
 alias_function do_build do_php_nginx_build_inner
 do_build() {
   do_php_nginx_build_inner
+  do_build_permissions
   do_composer
 }
 
@@ -18,5 +19,6 @@ do_start() {
 alias_function do_development_start do_php_nginx_development_start_inner
 do_development_start() {
   do_php_nginx_development_start_inner
+  do_build_permissions
   do_composer
 }

--- a/php-nginx/usr/local/share/php/common_functions.sh
+++ b/php-nginx/usr/local/share/php/common_functions.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+do_build_permissions() {
+  if [ "$IS_NFS" -ne 0 ]; then
+    setfacl -R -m "d:u:$CODE_OWNER:rwX" -m "u:$CODE_OWNER:rwX" /app/
+  else
+    chown -R "$CODE_OWNER:$CODE_GROUP" /app/
+  fi
+}
+
 run_composer() {
   if [ ! -d "/app/vendor" ] || [ ! -f "/app/vendor/autoload.php" ]; then
     mkdir -p /app/vendor

--- a/symfony-nginx/usr/local/share/symfony/symfony_functions.sh
+++ b/symfony-nginx/usr/local/share/symfony/symfony_functions.sh
@@ -10,7 +10,6 @@ do_symfony_build_permissions() {
     # Prepare a default parameters.yml. incenteev/parameters-handler can still update it
     mkdir -p /app/app/config
     [ ! -f /app/app/config/parameters.yml ] && echo 'parameters: {}' > /app/app/config/parameters.yml
-    setfacl -R -m "d:u:$CODE_OWNER:rwX" -m "u:$CODE_OWNER:rwX" /app/
 
     # Fix permissions so the web server user can write to cache and logs folders
     if [ "$SYMFONY_MAJOR_VERSION" -eq 2 ]; then


### PR DESCRIPTION
Should fix the inability for composer running as the build user to create /app/bin, for example.