### PR TITLE
Disable php-fpm env var clearing

### DIFF
--- a/php-nginx/etc/confd/templates/php-fpm/pool.conf.tmpl
+++ b/php-nginx/etc/confd/templates/php-fpm/pool.conf.tmpl
@@ -3,6 +3,7 @@ user = {{ getenv "APP_USER" }}
 group = {{ getenv "APP_GROUP" }}
 
 catch_workers_output = yes
+clear_env = no
 
 listen = /run/php{{ getenv "PHP_VERSION" }}-fpm.sock
 


### PR DESCRIPTION
So it can see the container's env vars