### PR TITLE
Do not call finalise script from the build part, as it needs external services like a database.

### DIFF
--- a/drupal8-apache/7.0/usr/local/share/container/baseimage-30.sh
+++ b/drupal8-apache/7.0/usr/local/share/container/baseimage-30.sh
@@ -25,9 +25,17 @@ do_composer() {
 
 do_drupal8_install() {
   bash /usr/local/share/drupal8/install.sh
-  bash /usr/local/share/drupal8/install_finalise.sh
 }
 
 do_drupal8_development_start() {
   bash /usr/local/share/drupal8/development/install.sh
+  do_drupal8_setup
+}
+
+do_setup() {
+  do_drupal8_setup
+}
+
+do_drupal8_setup() {
+  bash /usr/local/share/drupal8/install_finalise.sh
 }


### PR DESCRIPTION
Similar approach as taken in the magento1 image, allowing a setup step to trigger `container setup` in a CP configuration.