### PR TITLE
Add optional composer flags

### DIFF
--- a/php-apache/usr/local/share/env/40-stack
+++ b/php-apache/usr/local/share/env/40-stack
@@ -17,3 +17,13 @@ export AUTH_HTTP_REALM=${AUTH_HTTP_REALM:-Protected System}
 export AUTH_HTTP_FILE=${AUTH_HTTP_FILE:-/etc/apache2/htpasswd}
 export AUTH_HTTP_TYPE=${AUTH_HTTP_TYPE:-Basic}
 export AUTH_HTTP_HTPASSWD=${AUTH_HTTP_HTPASSWD:-}
+
+
+DEFAULT_COMPOSER_FLAGS="--no-interaction --optimize-autoloader"
+# Due to ordering of files, the 50-bootstrap setting of DEVELOPMENT_MODE will not
+# be taken account of here. Please set DEVELOPMENT_MODE explicitly if you wish to have
+# development composer dependencies.
+if [ "$DEVELOPMENT_MODE" -ne 0 ]; then
+  DEFAULT_COMPOSER_FLAGS="${DEFAULT_COMPOSER_FLAGS} --no-dev"
+fi
+export COMPOSER_INSTALL_FLAGS=${COMPOSER_INSTALL_FLAGS:-$DEFAULT_COMPOSER_FLAGS}

--- a/php-apache/usr/local/share/env/40-stack
+++ b/php-apache/usr/local/share/env/40-stack
@@ -23,7 +23,7 @@ DEFAULT_COMPOSER_FLAGS="--no-interaction --optimize-autoloader"
 # Due to ordering of files, the 50-bootstrap setting of DEVELOPMENT_MODE will not
 # be taken account of here. Please set DEVELOPMENT_MODE explicitly if you wish to have
 # development composer dependencies.
-if [ "$DEVELOPMENT_MODE" -ne 0 ]; then
+if [ -z "$DEVELOPMENT_MODE" ] || [ "$DEVELOPMENT_MODE" -ne 0 ]; then
   DEFAULT_COMPOSER_FLAGS="${DEFAULT_COMPOSER_FLAGS} --no-dev"
 fi
 export COMPOSER_INSTALL_FLAGS=${COMPOSER_INSTALL_FLAGS:-$DEFAULT_COMPOSER_FLAGS}

--- a/php-apache/usr/local/share/php/common_functions.sh
+++ b/php-apache/usr/local/share/php/common_functions.sh
@@ -19,7 +19,7 @@ run_composer() {
       as_code_owner "composer global config github-oauth.github.com '$GITHUB_TOKEN'"
     fi
 
-    as_code_owner "composer install --no-interaction --optimize-autoloader"
+    as_code_owner "composer install ${COMPOSER_INSTALL_FLAGS}"
     rm -rf /home/build/.composer/cache/
     as_code_owner "composer clear-cache"
 

--- a/php-nginx/usr/local/share/env/40-stack
+++ b/php-nginx/usr/local/share/env/40-stack
@@ -25,3 +25,12 @@ export AUTH_HTTP_REALM=${AUTH_HTTP_REALM:-Protected System}
 export AUTH_HTTP_FILE=${AUTH_HTTP_FILE:-/etc/nginx/htpasswd}
 export AUTH_HTTP_REMOTE_URL=${AUTH_HTTP_REMOTE_URL:-}
 export AUTH_HTTP_HTPASSWD=${AUTH_HTTP_HTPASSWD:-}
+
+DEFAULT_COMPOSER_FLAGS="--no-interaction --optimize-autoloader"
+# Due to ordering of files, the 50-bootstrap setting of DEVELOPMENT_MODE will not
+# be taken account of here. Please set DEVELOPMENT_MODE explicitly if you wish to have
+# development composer dependencies.
+if [ "$DEVELOPMENT_MODE" -ne 0 ]; then
+  DEFAULT_COMPOSER_FLAGS="${DEFAULT_COMPOSER_FLAGS} --no-dev"
+fi
+export COMPOSER_INSTALL_FLAGS=${COMPOSER_INSTALL_FLAGS:-$DEFAULT_COMPOSER_FLAGS}

--- a/php-nginx/usr/local/share/env/40-stack
+++ b/php-nginx/usr/local/share/env/40-stack
@@ -30,7 +30,7 @@ DEFAULT_COMPOSER_FLAGS="--no-interaction --optimize-autoloader"
 # Due to ordering of files, the 50-bootstrap setting of DEVELOPMENT_MODE will not
 # be taken account of here. Please set DEVELOPMENT_MODE explicitly if you wish to have
 # development composer dependencies.
-if [ "$DEVELOPMENT_MODE" -ne 0 ]; then
+if [ -z "$DEVELOPMENT_MODE" ] || [ "$DEVELOPMENT_MODE" -ne 0 ]; then
   DEFAULT_COMPOSER_FLAGS="${DEFAULT_COMPOSER_FLAGS} --no-dev"
 fi
 export COMPOSER_INSTALL_FLAGS=${COMPOSER_INSTALL_FLAGS:-$DEFAULT_COMPOSER_FLAGS}

--- a/php-nginx/usr/local/share/php/common_functions.sh
+++ b/php-nginx/usr/local/share/php/common_functions.sh
@@ -19,7 +19,7 @@ run_composer() {
       as_code_owner "composer global config github-oauth.github.com '$GITHUB_TOKEN'"
     fi
 
-    as_code_owner "composer install --no-interaction --optimize-autoloader"
+    as_code_owner "composer install ${COMPOSER_INSTALL_FLAGS}"
     rm -rf /home/build/.composer/cache/
     as_code_owner "composer clear-cache"
 


### PR DESCRIPTION
Adds `--no-dev` if not in DEVELOPMENT_MODE, though you can influence it at a higher image level by declaring COMPOSER_INSTALL_FLAGS.

This can be used by the symfony image for example, to disable the update parameters plugin.