### PR TITLE
Remove http2 from another nginx http port conf

### DIFF
--- a/php-nginx/etc/confd/templates/nginx/site.conf.tmpl
+++ b/php-nginx/etc/confd/templates/nginx/site.conf.tmpl
@@ -12,7 +12,7 @@ server {
     server_name _;
 {{ end }}
 {{ if eq "true" (getenv "WEB_HTTPS_OFFLOADED") }}
-    listen {{ getenv "WEB_HTTPS_PORT" }} default_server http2;{{ else }}
+    listen {{ getenv "WEB_HTTPS_PORT" }} default_server;{{ else }}
     listen {{ getenv "WEB_HTTPS_PORT" }} default_server ssl http2;
     ssl_certificate {{ getenv "WEB_SSL_FULLCHAIN" }};
     ssl_certificate_key {{ getenv "WEB_SSL_PRIVKEY" }};{{ end }}{{ end }}


### PR DESCRIPTION
Nginx doesn't support http/1.1 upgrade to 2.0 on standard http