### PR TITLE
Do not call finalise script from the build part, as it needs external services like a database.

### DIFF
--- a/magento2-nginx/fpm-7.0/usr/local/share/container/baseimage-30.sh
+++ b/magento2-nginx/fpm-7.0/usr/local/share/container/baseimage-30.sh
@@ -19,10 +19,18 @@ do_composer() {
 
 do_magento2_install() {
   bash /usr/local/share/magento2/install_magento.sh
+}
+
+do_setup() {
+  do_magento2_setup
+}
+
+do_magento2_setup() {
   bash /usr/local/share/magento2/install_magento_finalise.sh
 }
 
 do_magento2_development_start()
 {
   bash /usr/local/share/magento2/development/install.sh
+  do_magento2_setup
 }


### PR DESCRIPTION
For magento 2, similar to the one for drupal 8 in #103 