### PR TITLE
Add php images PHP_VERSION as CP build environments

### DIFF
--- a/continuous-pipe.yml
+++ b/continuous-pipe.yml
@@ -51,21 +51,39 @@ tasks:
         php71_apache:
           image: quay.io/continuouspipe/php7.1-apache
           tag: latest
+          environment:
+            - name: PHP_VERSION
+              value: 7.1
         php70_apache:
           image: quay.io/continuouspipe/php7-apache
           tag: latest
+          environment:
+            - name: PHP_VERSION
+              value: 7.0
         php56_apache:
           image: quay.io/continuouspipe/php5.6-apache
           tag: latest
+          environment:
+            - name: PHP_VERSION
+              value: 5.6
         php71_nginx:
           image: quay.io/continuouspipe/php7.1-nginx
           tag: latest
+          environment:
+            - name: PHP_VERSION
+              value: 7.1
         php70_nginx:
           image: quay.io/continuouspipe/php7-nginx
           tag: latest
+          environment:
+            - name: PHP_VERSION
+              value: 7.0
         php56_nginx:
           image: quay.io/continuouspipe/php5.6-nginx
           tag: latest
+          environment:
+            - name: PHP_VERSION
+              value: 5.6
         scala_sbt:
           image: quay.io/continuouspipe/scala-base
           tag: latest


### PR DESCRIPTION
Continous Pipe doesn't read builild args from the docker-compose.yml so the PHP images were using the default 7.0 for 5.6 and 7.1