### PR TITLE
Add common php and symfony db/cache commands

### DIFF
--- a/php-apache/README.md
+++ b/php-apache/README.md
@@ -143,6 +143,7 @@ This base image adds the following bash functions:
 function | description | executed on
 --- | --- | ---
 do_composer | Runs composer install in /app if it's not been run yet | do_build, do_development_start
+do_composer_postinstall_scripts | runs composer post-install-cmd event to trigger scripts attached | nothing by default
 do_build_permissions | Ensures that /app is owned by the build user and not www-data or root, for security and ability to run composer as a non-root user | do_build, do_development_start
 
 These functions can be triggered via the /usr/local/bin/container command, dropping off the "do_" part. e.g:

--- a/php-apache/usr/local/share/php/common_functions.sh
+++ b/php-apache/usr/local/share/php/common_functions.sh
@@ -36,3 +36,7 @@ do_composer() {
     run_composer
   fi
 }
+
+do_composer_postinstall_scripts() {
+  as_code_owner 'composer run-script post-install-cmd'
+}

--- a/php-nginx/README.md
+++ b/php-nginx/README.md
@@ -148,6 +148,7 @@ This base image adds the following bash functions:
 function | description | executed on
 --- | --- | ---
 do_composer | Runs composer install in /app if it's not been run yet | do_build, do_development_start
+do_composer_postinstall_scripts | runs composer post-install-cmd event to trigger scripts attached | nothing by default
 do_nginx | Runs nginx-related setup scripts | do_start
 do_https_certificates | Ensures there are [HTTPS certificates](#ssl-certificateskey) | do_nginx
 do_build_permissions | Ensures that /app is owned by the build user and not www-data or root, for security and ability to run composer as a non-root user | do_build, do_development_start

--- a/php-nginx/usr/local/share/php/common_functions.sh
+++ b/php-nginx/usr/local/share/php/common_functions.sh
@@ -36,3 +36,7 @@ do_composer() {
     run_composer
   fi
 }
+
+do_composer_postinstall_scripts() {
+  as_code_owner 'composer run-script post-install-cmd'
+}

--- a/symfony/README.md
+++ b/symfony/README.md
@@ -77,6 +77,14 @@ do_symfony_build | Updates the permissions of the Symfony app as required for co
 do_symfony_config_create | Creates an empty parameters.yml that the composer installation can update via the incenteev/parameters-handler package | do_symfony_build
 do_symfony_directory_create | Creates directories that may not be present in the codebase but are required before composer can run to install dependencies | do_symfony_build
 do_symfony_build_permissions | Fix the owner and permissions of the web-writable directories, to allow symfony to function | do_composer
+do_cache_clear | Clears/warms up the Symfony cache | nothing by default
+do_database_build | Installs or updates the database schema depending on whether the database exists | nothing by default
+do_database_install | Runs database install process (assumes Doctrine ORM/migrations), which is by default do_database_schema_create, do_database_migrations_mark_done, do_database_fixtures | do_database_build
+do_database_update | Runs database update process(assumes Doctrine ORM/migrations), which is by default do_database_migrate | do_database_build
+do_database_schema_create | Runs doctrine:schema:create | do_database_install
+do_database_schema_update | Runs doctrine:schema:update --force (not recommmended) | nothing by default
+do_database_migrations_mark_done | Marks all Doctrine migrations as done | do_database_install
+do_database_migrate | Runs doctrine:migrations:migrate --no-interaction | do_database_update
 
 These functions can be triggered via the /usr/local/bin/container command, dropping off the "do_" part. e.g:
 

--- a/symfony/usr/local/share/symfony/symfony_functions.sh
+++ b/symfony/usr/local/share/symfony/symfony_functions.sh
@@ -44,6 +44,61 @@ do_symfony_build_permissions() {
   do_symfony_composer_permissions
 }
 
+do_database_rebuild() {
+  as_app_user './app/console doctrine:database:drop --force >/dev/null || true'
+  do_database_build
+}
+
+do_database_build() {
+  # load the database if it doesn't exist
+  set +e
+  as_app_user './app/console doctrine:database:create >/dev/null'
+  DATABASE_EXISTED=$?
+  set -e
+
+  if [ "$DATABASE_EXISTED" -ne 1 ]; then
+    do_database_install
+  else
+    do_database_update
+  fi
+}
+
+do_database_install() {
+  do_database_schema_create
+  do_database_migrations_mark_done
+  do_database_fixtures
+}
+
+do_database_update() {
+  do_database_migrate
+}
+
+do_database_schema_create() {
+  as_app_user './app/console doctrine:schema:create'
+}
+
+do_database_schema_update() {
+  as_app_user './app/console doctrine:schema:update --force'
+}
+
+do_database_migrations_mark_done() {
+  as_app_user './app/console doctrine:migrations:version --add --all --no-interaction'
+}
+
+do_database_migrate() {
+  as_app_user './app/console doctrine:migrations:migrate --no-interaction'
+}
+
+do_cache_clear() {
+  as_app_user './app/console cache:clear'
+}
+
+do_database_fixtures() {
+  if [ "$SYMFONY_DATABASE_FIXTURE_INSTALL" -eq 1 ]; then
+    as_app_user './app/console doctrine:fixtures:load -n'
+  fi
+}
+
 do_symfony_build() {
   do_symfony_directory_create
   do_symfony_config_create


### PR DESCRIPTION
These are not attached to the container build or start by default, however can be attached without duplicating them in projects