### PR TITLE
Move symfony functions around to fix permissions issues

### DIFF
--- a/symfony/usr/local/share/container/baseimage-30.sh
+++ b/symfony/usr/local/share/container/baseimage-30.sh
@@ -2,9 +2,14 @@
 
 source /usr/local/share/symfony/symfony_functions.sh
 
+alias_function do_build_permissions do_symfony_build_permissions_inner
+do_build_permissions() {
+  do_symfony_build
+  do_symfony_build_permissions_inner
+}
+
 alias_function do_composer do_symfony_composer_inner
 do_composer() {
-  do_symfony_build
   do_symfony_composer_inner
-  do_symfony_build_permissions
+  do_symfony_app_permissions
 }

--- a/symfony/usr/local/share/symfony/symfony_functions.sh
+++ b/symfony/usr/local/share/symfony/symfony_functions.sh
@@ -4,12 +4,6 @@ do_symfony_config_create() {
   # Prepare a default parameters.yml. incenteev/parameters-handler can still update it
   if [ ! -f /app/app/config/parameters.yml ]; then
     echo 'parameters: {}' > /app/app/config/parameters.yml
-    if [ "$IS_CHOWN_FORBIDDEN" -ne 0 ]; then
-      chown "$CODE_OWNER:$APP_USER" /app/app/config/parameters.yml
-      chmod u+rw,g+r,o-rwx /app/app/config/parameters.yml
-    else
-      chmod a+rw /app/app/config/parameters.yml
-    fi
   fi
 }
 
@@ -21,27 +15,21 @@ do_symfony_directory_create() {
   mkdir -p /app/var
 }
 
-do_symfony_composer_permissions() {
-  # Allow composer to write to certain directories
-  if [ "$IS_CHOWN_FORBIDDEN" -ne 0 ]; then
-    chown -R "$APP_USER:$CODE_GROUP" /app/var
-    chmod -R ug+rw,o-rwx /app/var
-  else
-    chmod -R a+rw /app/var
-  fi
-}
-
-do_symfony_build_permissions() {
+do_symfony_app_permissions() {
   if [ "$IS_CHOWN_FORBIDDEN" -ne 0 ]; then
     # Fix permissions so the web server user can write to cache and logs folders
     if [ "$SYMFONY_MAJOR_VERSION" -eq 2 ]; then
       chown -R "$APP_USER:$CODE_GROUP" /app/app/{cache,logs}
       chmod -R ug+rw,o-rwx /app/app/{cache,logs}
     fi
-  elif [ "$SYMFONY_MAJOR_VERSION" -eq 2 ]; then
-    chmod -R a+rw /app/app/{cache,logs}
+    chown -R "$APP_USER:$CODE_GROUP" /app/var
+    chmod -R ug+rw,o-rwx /app/var
+  else
+    if [ "$SYMFONY_MAJOR_VERSION" -eq 2 ]; then
+      chmod -R a+rw /app/app/{cache,logs}
+    fi
+    chmod -R a+rw /app/var
   fi
-  do_symfony_composer_permissions
 }
 
 do_database_rebuild() {
@@ -107,5 +95,4 @@ do_database_fixtures() {
 do_symfony_build() {
   do_symfony_directory_create
   do_symfony_config_create
-  do_symfony_composer_permissions
 }


### PR DESCRIPTION
* Merge symfony composer and build permissions, as they related to the same thing, and are for app permissions rather than build
* Move that then to after composer is run (no need for app permissions before that)
* Move do_symfony_build to before parent build permissions