### PR TITLE
Allow composer to be run multiple times

### DIFF
--- a/php-apache/usr/local/share/php/common_functions.sh
+++ b/php-apache/usr/local/share/php/common_functions.sh
@@ -9,26 +9,13 @@ do_build_permissions() {
 }
 
 run_composer() {
-  if [ ! -d "/app/vendor" ] || [ ! -f "/app/vendor/autoload.php" ]; then
-    mkdir -p /app/vendor
-    if [ "$IS_CHOWN_FORBIDDEN" -ne 0 ]; then
-      chown "$CODE_OWNER":"$CODE_GROUP" /app/vendor
-    fi
-
-    if [ -n "$GITHUB_TOKEN" ]; then
-      as_code_owner "composer global config github-oauth.github.com '$GITHUB_TOKEN'"
-    fi
-
-    as_code_owner "composer install ${COMPOSER_INSTALL_FLAGS}"
-    rm -rf /home/build/.composer/cache/
-    as_code_owner "composer clear-cache"
-
-    if [ "$IS_CHOWN_FORBIDDEN" -ne 0 ]; then
-      chown -R "$CODE_OWNER:$APP_GROUP" /app/vendor
-    fi
-
-    chmod -R go-w /app/vendor
+  if [ -n "$GITHUB_TOKEN" ]; then
+    as_code_owner "composer global config github-oauth.github.com '$GITHUB_TOKEN'"
   fi
+
+  as_code_owner "composer install ${COMPOSER_INSTALL_FLAGS}"
+  rm -rf /home/build/.composer/cache/
+  as_code_owner "composer clear-cache"
 }
 
 do_composer() {

--- a/php-nginx/usr/local/share/php/common_functions.sh
+++ b/php-nginx/usr/local/share/php/common_functions.sh
@@ -9,26 +9,13 @@ do_build_permissions() {
 }
 
 run_composer() {
-  if [ ! -d "/app/vendor" ] || [ ! -f "/app/vendor/autoload.php" ]; then
-    mkdir -p /app/vendor
-    if [ "$IS_CHOWN_FORBIDDEN" -ne 0 ]; then
-      chown "$CODE_OWNER":"$CODE_GROUP" /app/vendor
-    fi
-
-    if [ -n "$GITHUB_TOKEN" ]; then
-      as_code_owner "composer global config github-oauth.github.com '$GITHUB_TOKEN'"
-    fi
-
-    as_code_owner "composer install ${COMPOSER_INSTALL_FLAGS}"
-    rm -rf /home/build/.composer/cache/
-    as_code_owner "composer clear-cache"
-
-    if [ "$IS_CHOWN_FORBIDDEN" -ne 0 ]; then
-      chown -R "$CODE_OWNER:$APP_GROUP" /app/vendor
-    fi
-
-    chmod -R go-w /app/vendor
+  if [ -n "$GITHUB_TOKEN" ]; then
+    as_code_owner "composer global config github-oauth.github.com '$GITHUB_TOKEN'"
   fi
+
+  as_code_owner "composer install ${COMPOSER_INSTALL_FLAGS}"
+  rm -rf /home/build/.composer/cache/
+  as_code_owner "composer clear-cache"
 }
 
 do_composer() {


### PR DESCRIPTION
This is so that it can be run at start with different composer flags to run (e.g. enabling require-dev dependencies)

Also the ownership and permissions changes look redundant:
* The first chown should already be covered by do_build_permissions
* The 2nd chown and chmod aren't really needed, as the app user can go through the "other" permissions for read access