### PR TITLE
Allow magento2 to write to env.php from the admin.

### DIFF
--- a/magento2-nginx/fpm-7.0/etc/confd/conf.d/magento_env.php.toml
+++ b/magento2-nginx/fpm-7.0/etc/confd/conf.d/magento_env.php.toml
@@ -1,7 +1,7 @@
 [template]
 src   = "magento/env.php.tmpl"
 dest  = "/app/app/etc/env.php"
-mode  = "0640"
+mode  = "0660"
 uid = 999
 gid = 33
 keys = [


### PR DESCRIPTION
Magento2 requires write access to env.php to turn on/off caching and other settings from the admin section.