### PR TITLE
Add cron to magento2

### DIFF
--- a/magento2-nginx/fpm-7.0/README.md
+++ b/magento2-nginx/fpm-7.0/README.md
@@ -85,3 +85,4 @@ MAGENTO_REDIS_CACHE_DATABASE | Redis database number to store block cache | data
 MAGENTO_REDIS_FULL_PAGE_CACHE_DATABASE | Redis database number to store full page cache | database number | 1
 MAGENTO_REDIS_SESSION_DATABASE | Redis database number to store sessions | database number | 2
 MAGENTO_ADMIN_FRONTNAME | Magento backend frontname | - | admin
+START_MODE | Start in "web" mode to serve a site, or "cron" mode to run the cron | (web|cron) | web

--- a/magento2-nginx/fpm-7.0/etc/confd/conf.d/magento_cron.toml
+++ b/magento2-nginx/fpm-7.0/etc/confd/conf.d/magento_cron.toml
@@ -1,0 +1,6 @@
+[template]
+src   = "magento/cron.tmpl"
+dest  = "/etc/cron.d/magento"
+mode  = "0644"
+keys = [
+]

--- a/magento2-nginx/fpm-7.0/etc/confd/conf.d/supervisor_magento_cron.conf.toml
+++ b/magento2-nginx/fpm-7.0/etc/confd/conf.d/supervisor_magento_cron.conf.toml
@@ -1,0 +1,6 @@
+[template]
+src   = "supervisor/magento_cron.conf.tmpl"
+dest  = "/etc/supervisor/conf.d/magento_cron.conf"
+mode  = "0644"
+keys = [
+]

--- a/magento2-nginx/fpm-7.0/etc/confd/templates/magento/cron.tmpl
+++ b/magento2-nginx/fpm-7.0/etc/confd/templates/magento/cron.tmpl
@@ -1,1 +1,5 @@
-* * * * * php-fpm (cd /app/ && php bin/magento cron:run)
+# don't send any mail
+MAILTO=""
+SUPERVISORCTL="supervisor -c /etc/supervisor/supervisord.conf -u supervisor -p supervisor"
+
+* * * * * root $SUPERVISORCTL start magento-cron

--- a/magento2-nginx/fpm-7.0/etc/confd/templates/magento/cron.tmpl
+++ b/magento2-nginx/fpm-7.0/etc/confd/templates/magento/cron.tmpl
@@ -1,0 +1,1 @@
+* * * * * php-fpm (cd /app/ && php bin/magento cron:run)

--- a/magento2-nginx/fpm-7.0/etc/confd/templates/supervisor/magento_cron.conf.tmpl
+++ b/magento2-nginx/fpm-7.0/etc/confd/templates/supervisor/magento_cron.conf.tmpl
@@ -1,0 +1,12 @@
+[program:magento-cron]
+command = cd /app/ && php bin/magento cron:run
+startsecs = 0
+startretries = 0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+user = {{ getenv "APP_USER"}}
+autostart = false
+autorestart = false
+priority = 5


### PR DESCRIPTION
Start with a dedicated entry in docker-compose.yml, passing "START_MODE=cron" as an environment variable
