### PR TITLE
Add to mysql images a MYSQL_DATABASE_GRANT env var

### DIFF
--- a/mysql/Dockerfile-5.6
+++ b/mysql/Dockerfile-5.6
@@ -1,3 +1,5 @@
 FROM mysql:5.6
 
+COPY ./docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
+
 MAINTAINER "Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>"

--- a/mysql/Dockerfile-5.7
+++ b/mysql/Dockerfile-5.7
@@ -1,3 +1,5 @@
 FROM mysql:5.7
 
+COPY ./docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
+
 MAINTAINER "Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>"

--- a/mysql/Dockerfile-8.0
+++ b/mysql/Dockerfile-8.0
@@ -1,3 +1,5 @@
 FROM mysql:8.0
 
+COPY ./docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
+
 MAINTAINER "Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>"

--- a/mysql/Dockerfile.tmpl
+++ b/mysql/Dockerfile.tmpl
@@ -1,3 +1,5 @@
 FROM mysql:{{IMAGE_TAG}}
 
+COPY ./docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d/
+
 MAINTAINER "Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>"

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -26,3 +26,9 @@ docker-compose push mysql56 mysql57 mysql80
 ## How to use
 
 As this is based on the library MySQL image, see their README on [The Docker Hub](https://hub.docker.com/_/mysql/).
+
+In addition to this, the following variables are supported:
+
+Variable | Description | Expected values | Default
+--- | --- | --- | ----
+MYSQL_DATABASE_GRANT | The database pattern to grant for the MYSQL_USER | a database pattern match | not set

--- a/mysql/docker-entrypoint-initdb.d/mysql_grants.sh
+++ b/mysql/docker-entrypoint-initdb.d/mysql_grants.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ "$MYSQL_USER" ] && [ "$MYSQL_PASSWORD" ]; then
+    if [ "$MYSQL_DATABASE_GRANT" ]; then
+        # shellcheck disable=SC2154
+        echo "GRANT ALL ON \`$MYSQL_DATABASE_GRANT\`.* TO '$MYSQL_USER'@'%' ;" | "${mysql[@]}"
+    fi
+fi


### PR DESCRIPTION
This is so that a pattern match can be used to allow multiple databases to be created rather than just one. No database is created by default though unlike MYSQL_DATABASE