### PR TITLE
Clear magento2 cache before setup upgrade

### DIFF
--- a/magento2-nginx/fpm-7.0/Dockerfile
+++ b/magento2-nginx/fpm-7.0/Dockerfile
@@ -11,6 +11,7 @@ RUN curl -q https://dx6pc3giz7k1r.cloudfront.net/GPG-KEY-inviqa-tools | apt-key 
  && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
     hem \
     nodejs \
+    redis-tools \
     rsyslog \
     sudo \
  \

--- a/magento2-nginx/fpm-7.0/usr/local/share/magento2/install_magento_finalise.sh
+++ b/magento2-nginx/fpm-7.0/usr/local/share/magento2/install_magento_finalise.sh
@@ -29,8 +29,9 @@ if [ -d pub/static/frontend/ ]; then
   mv pub/static/frontend/ /tmp/assets/
 fi
 
-rm -rf var/generated/
-as_code_owner "bin/magento cache:flush"
+rm -rf var/generation/*
+redis-cli -h "$REDIS_HOST" -p "$REDIS_HOST_PORT" -n "$MAGENTO_REDIS_CACHE_DATABASE" "FLUSHDB"
+redis-cli -h "$REDIS_HOST" -p "$REDIS_HOST_PORT" -n "$MAGENTO_REDIS_FULL_PAGE_CACHE_DATABASE" "FLUSHDB"
 as_code_owner "bin/magento setup:upgrade"
 
 if [ -d /tmp/assets/ ]; then

--- a/magento2-nginx/fpm-7.0/usr/local/share/magento2/install_magento_finalise.sh
+++ b/magento2-nginx/fpm-7.0/usr/local/share/magento2/install_magento_finalise.sh
@@ -29,6 +29,8 @@ if [ -d pub/static/frontend/ ]; then
   mv pub/static/frontend/ /tmp/assets/
 fi
 
+rm -rf var/generated/
+as_code_owner "bin/magento cache:clear"
 as_code_owner "bin/magento setup:upgrade"
 
 if [ -d /tmp/assets/ ]; then

--- a/magento2-nginx/fpm-7.0/usr/local/share/magento2/install_magento_finalise.sh
+++ b/magento2-nginx/fpm-7.0/usr/local/share/magento2/install_magento_finalise.sh
@@ -30,7 +30,7 @@ if [ -d pub/static/frontend/ ]; then
 fi
 
 rm -rf var/generated/
-as_code_owner "bin/magento cache:clear"
+as_code_owner "bin/magento cache:flush"
 as_code_owner "bin/magento setup:upgrade"
 
 if [ -d /tmp/assets/ ]; then


### PR DESCRIPTION
Needed as redis or the generated folder may a different version of magento cached. For example if upgrading versions. This causes "bin/magento" calls to fail to boot magento.