### PR TITLE
Fix HTTPS offloaded variable not being passed to magento2 via nginx.

### DIFF
--- a/magento2-nginx/fpm-7.0/etc/confd/templates/nginx/site_base.conf.tmpl
+++ b/magento2-nginx/fpm-7.0/etc/confd/templates/nginx/site_base.conf.tmpl
@@ -17,6 +17,7 @@ location ~* ^/setup($|/) {
         fastcgi_pass   php-fpm;
         fastcgi_index  index.php;
         fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+        fastcgi_param  HTTPS $custom_https if_not_empty;
         include        fastcgi_params;
     }
 
@@ -39,6 +40,7 @@ location ~* ^/update($|/) {
         fastcgi_index  index.php;
         fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
         fastcgi_param  PATH_INFO        $fastcgi_path_info;
+        fastcgi_param  HTTPS $custom_https if_not_empty;
         include        fastcgi_params;
     }
 

--- a/magento2-nginx/fpm-7.0/etc/confd/templates/nginx/site_phpfpm.conf.tmpl
+++ b/magento2-nginx/fpm-7.0/etc/confd/templates/nginx/site_phpfpm.conf.tmpl
@@ -13,6 +13,7 @@ location ~ (index|get|static|report|404|503)\.php$ {
 
     fastcgi_index  index.php;
     fastcgi_param  SCRIPT_FILENAME  $document_root$fastcgi_script_name;
+    fastcgi_param  HTTPS $custom_https if_not_empty;
     include        fastcgi_params;
 
     # Set Mage run Type and Code dynamically


### PR DESCRIPTION
The HTTPS value was not being passed through to Magento2, based on the $custom_https value set up in `/etc/nginx/sites-available/default-05-custom_scheme_flags.conf`