### PR TITLE
Fix supervisor cron template

### DIFF
--- a/magento1-nginx/fpm-5.6/etc/confd/templates/magento/cron.tmpl
+++ b/magento1-nginx/fpm-5.6/etc/confd/templates/magento/cron.tmpl
@@ -1,5 +1,5 @@
 # don't send any mail
 MAILTO=""
-SUPERVISORCTL="supervisor -c /etc/supervisor/supervisord.conf -u supervisor -p supervisor"
+SUPERVISORCTL="supervisorctl -c /etc/supervisor/supervisord.conf -u supervisor -p supervisor"
 
 * * * * * root $SUPERVISORCTL start magento-cron

--- a/magento2-nginx/fpm-7.0/etc/confd/templates/magento/cron.tmpl
+++ b/magento2-nginx/fpm-7.0/etc/confd/templates/magento/cron.tmpl
@@ -1,5 +1,5 @@
 # don't send any mail
 MAILTO=""
-SUPERVISORCTL="supervisor -c /etc/supervisor/supervisord.conf -u supervisor -p supervisor"
+SUPERVISORCTL="supervisorctl -c /etc/supervisor/supervisord.conf -u supervisor -p supervisor"
 
 * * * * * root $SUPERVISORCTL start magento-cron


### PR DESCRIPTION
While using this cron setup in another docker image I found cron was not running as expected.

Running the command directly in the container:
supervisor -c /etc/supervisor/supervisord.conf -u supervisor -p supervisor start magento-cron
> bash: supervisor: command not found

Updating to supervisorctl fixed the issue, so I expect this applies here too.