### PR TITLE
Add redis configuration link.

### DIFF
--- a/redis/3.2/README.md
+++ b/redis/3.2/README.md
@@ -6,10 +6,14 @@ FROM quay.io/continuouspipe/redis3:stable
 
 ## How to build
 ```bash
-docker build --pull --tag quay.io/continuouspipe/redis3:stable --rm .
-docker push
+docker-compose build redis
+docker-compose push redis
 ```
 
 ## How to use
 
 As this is based on the library Redis image, see their README on [The Docker Hub](https://hub.docker.com/_/redis/).
+
+The default configuration for Redis 3.2.7 will be used when not building a custom image from this one.
+You can find the default configuration here:
+[Redis 3.2.7 configuration](https://github.com/antirez/redis/blob/3.2.7/redis.conf).


### PR DESCRIPTION
In investigating what the maxmemory setting was set to, I found that redis-server is not starting with a configuration file specified, so the default is used.

I have added a link to the default configuration for the (current) version in the image.