### PR TITLE
Fix Firefox taking a long time to verify the chain

### DIFF
--- a/nginx/usr/local/share/nginx/nginx_functions.sh
+++ b/nginx/usr/local/share/nginx/nginx_functions.sh
@@ -21,6 +21,7 @@ function do_https_certificates() {
             -days 365 \
             -newkey rsa:2048 \
             -keyout "${WEB_SSL_PRIVKEY}" \
+            -outform PEM \
             -out "${WEB_SSL_FULLCHAIN}" \
             -subj "/C=SS/ST=SS/L=SelfSignedCity/O=SelfSignedOrg/CN=${WEB_HOST}"
     elif [ -e "${WEB_SSL_PRIVKEY}" ] && [ -e "${WEB_SSL_FULLCHAIN}" ]; then

--- a/php-apache/usr/local/share/php/apache_functions.sh
+++ b/php-apache/usr/local/share/php/apache_functions.sh
@@ -21,6 +21,7 @@ function do_https_certificates() {
             -days 365 \
             -newkey rsa:2048 \
             -keyout "${WEB_SSL_PRIVKEY}" \
+            -outform PEM \
             -out "${WEB_SSL_FULLCHAIN}" \
             -subj "/C=SS/ST=SS/L=SelfSignedCity/O=SelfSignedOrg/CN=${WEB_HOST}"
     elif [ -e "${WEB_SSL_PRIVKEY}" ] && [ -e "${WEB_SSL_FULLCHAIN}" ]; then

--- a/php-nginx/usr/local/share/php/nginx_functions.sh
+++ b/php-nginx/usr/local/share/php/nginx_functions.sh
@@ -21,6 +21,7 @@ function do_https_certificates() {
             -days 365 \
             -newkey rsa:2048 \
             -keyout "${WEB_SSL_PRIVKEY}" \
+            -outform PEM \
             -out "${WEB_SSL_FULLCHAIN}" \
             -subj "/C=SS/ST=SS/L=SelfSignedCity/O=SelfSignedOrg/CN=${WEB_HOST}"
     elif [ -e "${WEB_SSL_PRIVKEY}" ] && [ -e "${WEB_SSL_FULLCHAIN}" ]; then


### PR DESCRIPTION
For self-signed certificates. Similar fix to https://github.com/inviqa/chef-magento/pull/79

Needs to be tested! Seems to only affect OSX. Windows 10 unaffected by the slow resolution time.