### PR TITLE
Fix magento2 cron

### DIFF
--- a/magento2-nginx/fpm-7.0/etc/confd/templates/supervisor/magento_cron.conf.tmpl
+++ b/magento2-nginx/fpm-7.0/etc/confd/templates/supervisor/magento_cron.conf.tmpl
@@ -1,5 +1,5 @@
 [program:magento-cron]
-command = cd /app/ && php bin/magento cron:run
+command = /bin/bash -c "cd /app/ && php bin/magento cron:run"
 startsecs = 0
 startretries = 0
 stdout_logfile=/dev/stdout


### PR DESCRIPTION
Fix magento2 cron by having the full path to the command being executed in supervisor's config.