### PR TITLE
Create a ssh-forward image for supporting local/remote port forwarding and …

### DIFF
--- a/continuous-pipe.yml
+++ b/continuous-pipe.yml
@@ -158,6 +158,9 @@ tasks:
         scala_sbt:
           image: quay.io/continuouspipe/scala-base
           tag: latest
+        ssh_forward:
+          image: quay.io/continuouspipe/ssh-forward
+          tag: latest
         symfony_php71_nginx:
           image: quay.io/continuouspipe/symfony-php7.1-nginx
           tag: latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -255,6 +255,15 @@ services:
     depends_on:
       - external_solr_6_2
 
+  ssh_forward:
+    build:
+      context: ./ssh-forward/
+    image: quay.io/continuouspipe/ssh-forward:latest
+    ports:
+      - '2222:22'
+    depends_on:
+      - ubuntu
+
   symfony_php71_nginx:
     build:
       context: ./symfony/

--- a/ssh-forward/Dockerfile
+++ b/ssh-forward/Dockerfile
@@ -1,0 +1,20 @@
+FROM quay.io/continuouspipe/ubuntu16.04:latest
+
+MAINTAINER Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>
+
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
+    ssh \
+ \
+ # Clean the image \
+ && apt-get auto-remove -qq -y \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
+ && mkdir /var/run/sshd \
+ && useradd --create-home forward \
+ && echo "ForceCommand echo 'This account can only be used for ssh port forwarding'" >> /etc/ssh/sshd_config
+
+COPY ./etc/ /etc
+COPY ./usr/ /usr
+
+EXPOSE 22

--- a/ssh-forward/README.md
+++ b/ssh-forward/README.md
@@ -22,6 +22,10 @@ This is a Docker image to use for ssh port forwarding. For instance in order to
 run Selenium Webdriver locally while running Behat on the docker container, or
 for PHP XDebug remote debugging
 
+Note: it's not recommended to expose this container's ssh port to the public
+internet. Local docker development it's ok to expose it to the host's localhost.
+Kubernetes has local port forwarding that can expose the SSH port from a cluster to localhost.
+
 ## How to use
 
 ### Environment variables

--- a/ssh-forward/README.md
+++ b/ssh-forward/README.md
@@ -1,0 +1,86 @@
+# SSH forward
+
+```yml
+version: '3'
+services:
+  sshforward:
+    image: quay.io/continuouspipe/ssh-forward:stable
+    environment:
+      SSH_FORWARD_PASSWORD: forward
+      SSH_AUTHORIZED_KEYS: "ssh-rsa AAA..."
+```
+
+## How to build
+```bash
+docker-compose build ssh_forward
+docker-compose push ssh_forward
+```
+
+## About
+
+This is a Docker image to use for ssh port forwarding. For instance in order to
+run Selenium Webdriver locally while running Behat on the docker container, or
+for PHP XDebug remote debugging
+
+## How to use
+
+### Environment variables
+
+The following variables are supported
+
+Variable | Description | Expected values | Default
+--- | --- | --- | ----
+SSH_FORWARD_PASSWORD | Sets a password for the 'forward' user for use with SSH with password authentication | password | unset
+SSH_AUTHORIZED_KEYS | Sets the authorized ssh keys for the 'forward' user for use with  SSH with public key authentication | line-delimited ssh public keys | unset
+
+## Examples
+
+### Remote port forwarding a local selenium Webdriver service on port 4444
+
+If via CP, get access to the sshforward port locally
+
+```bash
+cp-remote forward -s sshforward 2222:22
+```
+
+If via local Docker, this assumes you've exposed port 22 to localhost:2222
+
+Next:
+
+Remote port forward localhost:4444
+
+```
+ssh -p 2222 forward@localhost -N -R 4444:localhost:4444
+```
+
+Add a behat profile extending default to behat.yml:
+
+```
+sshforward:
+  extensions:
+    Behat\MinkExtension:
+      selenium2:
+        wd_host: http://sshforward:4444/wd/hub
+```
+
+Run behat
+
+### SOCKS proxy into a K8S cluster or Docker for Mac/Windows
+
+If via CP, get access to the sshforward port locally
+
+```bash
+cp-remote forward -s sshforward 2222:22
+```
+
+If via Docker for Mac/Windows, this assumes you've exposed port sshforward:22 to localhost:2222
+
+Next:
+
+Set up a SSH SOCKS proxy:
+
+```bash
+ssh -p 2222 forward@localhost -N -D 1080
+```
+
+Configure your browser to use localhost:1080 as a SOCKS proxy

--- a/ssh-forward/etc/supervisor/conf.d/sshd.conf
+++ b/ssh-forward/etc/supervisor/conf.d/sshd.conf
@@ -1,0 +1,10 @@
+[program:sshd]
+command = /usr/sbin/sshd -D
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+loglevel = warn
+user = root
+autorestart = true
+priority = 5

--- a/ssh-forward/usr/local/share/container/baseimage-20.sh
+++ b/ssh-forward/usr/local/share/container/baseimage-20.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+do_ssh_forward_set_credentials() {
+  if [ -n "${SSH_FORWARD_PASSWORD}" ]; then
+    echo "forward:${SSH_FORWARD_PASSWORD}" | chpasswd
+  fi
+
+  if [ -n "${SSH_FORWARD_AUTHORIZED_KEYS}" ]; then
+    (
+      umask 0077
+      mkdir /home/forward/.ssh
+      echo "${SSH_FORWARD_AUTHORIZED_KEYS}" > /home/forward/.ssh/authorized_keys
+    )
+  fi
+}
+
+alias_function do_start do_ssh_forward_start_inner
+do_start() {
+  do_ssh_forward_set_credentials
+  do_ssh_forward_start_inner
+}


### PR DESCRIPTION
…SOCKS proxy

This is multi-purpose for example to solve:

* Seeing behat tests running in a local browser
* Using PHP XDebug remote debugging in an IDE
* SOCKS proxying into Docker for Mac for direct browsing unexposed http/https