### PR TITLE
Add only MONGODB prefix env vars to MongoDB auth script

### DIFF
--- a/mongodb/usr/local/bin/mongo-init.sh
+++ b/mongodb/usr/local/bin/mongo-init.sh
@@ -13,7 +13,7 @@ if [ -n "$MONGODB_ADMIN_USER" ] || [ -n "$MONGODB_USERS" ]; then
         mongo --nodb mongo-startup.js
 
         echo 'var env = {};' > env.js
-        export | sed 's/declare -x /env./' >> env.js
+        export | sed -e 's/declare -x /env./;' | grep '^env.MONGODB' >> env.js
 
         mongo mongo-set-auth.js
 


### PR DESCRIPTION
affinity:container was an environment variable when using docker-compose up (I'd only tested docker-comose run)
This parsed incorrectly, so a fix was to only include the needed env vars