### PR TITLE
Default to saying we are being talked to over https.

### DIFF
--- a/nginx/etc/confd/templates/nginx/site_custom_scheme_flags.conf.tmpl
+++ b/nginx/etc/confd/templates/nginx/site_custom_scheme_flags.conf.tmpl
@@ -1,12 +1,15 @@
-{{ if eq "false" (getenv "WEB_REVERSE_PROXIED") }}
-set $custom_https $https;
-set $custom_scheme $scheme;{{ else }}
-set $custom_https '';
-set $custom_scheme http;
+set $custom_https on;
+set $custom_scheme https;
+
+if ($http_x_forwarded_proto = '') {
+  set $custom_scheme $scheme;
+  set $custom_https $https;
+}
+
 if ($http_x_forwarded_proto) {
     set $custom_scheme $http_x_forwarded_proto;
 }
 
-if ($http_x_forwarded_proto = https) {
-    set $custom_https on;
-}{{ end }}
+if ($http_x_forwarded_proto = http) {
+    set $custom_https off;
+}

--- a/nginx/etc/confd/templates/nginx/site_redirect_to_https.conf.tmpl
+++ b/nginx/etc/confd/templates/nginx/site_redirect_to_https.conf.tmpl
@@ -1,9 +1,7 @@
-{{ if eq "true" (getenv "WEB_REVERSE_PROXIED") }}
-  if ($custom_scheme = 'https') {
-    set $do_https_redirect 0;
-  }
+if ($custom_scheme = 'https') {
+  set $do_https_redirect 0;
+}
 
-  if ($do_https_redirect != 0) {
-    rewrite ^ https://$host$request_uri? permanent;
-  }
-{{ end }}
+if ($do_https_redirect != 0) {
+  rewrite ^ https://$host$request_uri? permanent;
+}

--- a/php-nginx/etc/confd/templates/nginx/site_custom_scheme_flags.conf.tmpl
+++ b/php-nginx/etc/confd/templates/nginx/site_custom_scheme_flags.conf.tmpl
@@ -1,12 +1,15 @@
-{{ if eq "false" (getenv "WEB_REVERSE_PROXIED") }}
-set $custom_https $https;
-set $custom_scheme $scheme;{{ else }}
-set $custom_https '';
-set $custom_scheme http;
+set $custom_https on;
+set $custom_scheme https;
+
+if ($http_x_forwarded_proto = '') {
+  set $custom_scheme $scheme;
+  set $custom_https $https;
+}
+
 if ($http_x_forwarded_proto) {
     set $custom_scheme $http_x_forwarded_proto;
 }
 
-if ($http_x_forwarded_proto = https) {
-    set $custom_https on;
-}{{ end }}
+if ($http_x_forwarded_proto = http) {
+    set $custom_https off;
+}

--- a/php-nginx/etc/confd/templates/nginx/site_redirect_to_https.conf.tmpl
+++ b/php-nginx/etc/confd/templates/nginx/site_redirect_to_https.conf.tmpl
@@ -1,9 +1,7 @@
-{{ if eq "true" (getenv "WEB_REVERSE_PROXIED") }}
-  if ($custom_scheme = 'https') {
-    set $do_https_redirect 0;
-  }
+if ($custom_scheme = 'https') {
+  set $do_https_redirect 0;
+}
 
-  if ($do_https_redirect != 0) {
-    rewrite ^ https://$host$request_uri? permanent;
-  }
-{{ end }}
+if ($do_https_redirect != 0) {
+  rewrite ^ https://$host$request_uri? permanent;
+}


### PR DESCRIPTION
So when a reverse proxy is talking to us securely over port 443, we don't have to set WEB_REVERSE_PROXIED=true to stop secure traffic from being served over HTTP at the reverse proxy.
i.e. HTTP from client to reverse proxy, HTTPS from reverse proxy to container.

This makes for a more transparent developer experience as we didn't have to do anything special.

* If talked to over HTTP with a reverse proxy in the middle, X-Forwarded-Proto will be "http" and a the $custom_scheme check will perform a 301 to https
* If talked to over HTTPS with a reverse proxy in the middle, X-Forwarded-Proto will be "https", so no redirect will happen due to satisfying the $custom_scheme check and talking to port 443 vhost.
* If talked to over HTTP without a reverse proxy in the middle, X-Forwarded-Proto will be empty, so $scheme will be used and will we "http", so the $custom_scheme check will perform a 301 to https.
* If talked to over HTTPS without a reverse proxy in the middle, X-Forwarded-Proto will be empty, so $scheme will be used and will be "https", so no redirect will happen due to satisfying the $custom_scheme check and talking to port 443 vhost.
* If X-Forwarded-Proto is spoofed to "https" without a reverse proxy in the middle when talking to HTTP, the port 80 vhost will perform a 301 to https.
* If X-Forwarded-Proto is spoofed to "https" without a reverse proxy in the middle when talking to HTTPS, the port 443 host will be used so no redirect will happen (and that's okay!).
* If X-Forwarded-Proto is spoofed to "http" without a reverse proxy in the middle when talking to HTTP, the $custom_scheme check will perform a 301 to https.
* If X-Forwarded-Proto is spoofed to "http" without a reverse proxy in the middle when talking to HTTPS, the $custom_scheme check will perform a 301 to https.