### PR TITLE
Reverse proxy and https offload fixes

### DIFF
--- a/nginx/etc/confd/templates/nginx/site_custom_scheme_flags.conf.tmpl
+++ b/nginx/etc/confd/templates/nginx/site_custom_scheme_flags.conf.tmpl
@@ -1,4 +1,3 @@
-{{ if eq "false" (getenv "WEB_REVERSE_PROXIED") }}
 set $custom_https $https;
 set $custom_scheme $scheme;
 
@@ -6,9 +5,9 @@ set $custom_scheme $scheme;
 if ($server_port = {{ getenv "WEB_HTTPS_PORT" }} ) {
    set $custom_https on;
    set $custom_scheme https;
-}
-{{ end }}
-{{ else }}
+}{{ end }}
+
+{{ if eq "true" (getenv "WEB_REVERSE_PROXIED") }}
 set $custom_https '';
 set $custom_scheme http;
 if ($http_x_forwarded_proto) {

--- a/nginx/etc/confd/templates/nginx/site_custom_scheme_flags.conf.tmpl
+++ b/nginx/etc/confd/templates/nginx/site_custom_scheme_flags.conf.tmpl
@@ -1,6 +1,14 @@
 {{ if eq "false" (getenv "WEB_REVERSE_PROXIED") }}
 set $custom_https $https;
-set $custom_scheme $scheme;{{ else }}
+set $custom_scheme $scheme;
+
+{{ if eq "true" (getenv "WEB_HTTPS_OFFLOADED") }}
+if ($server_port = {{ getenv "WEB_HTTPS_PORT" }} ) {
+   set $custom_https on;
+   set $custom_scheme https;
+}
+{{ end }}
+{{ else }}
 set $custom_https '';
 set $custom_scheme http;
 if ($http_x_forwarded_proto) {

--- a/php-nginx/etc/confd/templates/nginx/site_custom_scheme_flags.conf.tmpl
+++ b/php-nginx/etc/confd/templates/nginx/site_custom_scheme_flags.conf.tmpl
@@ -1,4 +1,3 @@
-{{ if eq "false" (getenv "WEB_REVERSE_PROXIED") }}
 set $custom_https $https;
 set $custom_scheme $scheme;
 
@@ -6,9 +5,9 @@ set $custom_scheme $scheme;
 if ($server_port = {{ getenv "WEB_HTTPS_PORT" }} ) {
    set $custom_https on;
    set $custom_scheme https;
-}
-{{ end }}
-{{ else }}
+}{{ end }}
+
+{{ if eq "true" (getenv "WEB_REVERSE_PROXIED") }}
 set $custom_https '';
 set $custom_scheme http;
 if ($http_x_forwarded_proto) {

--- a/php-nginx/etc/confd/templates/nginx/site_custom_scheme_flags.conf.tmpl
+++ b/php-nginx/etc/confd/templates/nginx/site_custom_scheme_flags.conf.tmpl
@@ -1,6 +1,14 @@
 {{ if eq "false" (getenv "WEB_REVERSE_PROXIED") }}
 set $custom_https $https;
-set $custom_scheme $scheme;{{ else }}
+set $custom_scheme $scheme;
+
+{{ if eq "true" (getenv "WEB_HTTPS_OFFLOADED") }}
+if ($server_port = {{ getenv "WEB_HTTPS_PORT" }} ) {
+   set $custom_https on;
+   set $custom_scheme https;
+}
+{{ end }}
+{{ else }}
 set $custom_https '';
 set $custom_scheme http;
 if ($http_x_forwarded_proto) {


### PR DESCRIPTION
This is a compromise over #199.

Instead, WEB_REVERSE_PROXIED can be safely turned on for all our CP environments without dictating that for other users. We can separately consider whether the images should have it enabled by default.

WEB_HTTPS_OFFLOAD = use server port to be scheme authority, when https port doesn't use SSL.
WEB_REVERSE_PROXIED = use request headers if available to be scheme authority, otherwise fall back to nginx scheme