### PR TITLE
Split out HTTPS only logic into another variable

### DIFF
--- a/nginx/README.md
+++ b/nginx/README.md
@@ -60,11 +60,12 @@ The following variables are supported
 Variable | Description | Expected values | Default
 --- | --- | --- | ----
 WEB_HOST | The domain of the website | a domain | localhost
-WEB_HTTP | Whether to support HTTP traffic on the WEB_HTTP_PORT. If auto, it's behaviour is the reverse setting of WEB_HTTPS, and if false, will redirect to HTTPS. | true/false/auto | auto
+WEB_HTTP | Whether to support HTTP traffic on the WEB_HTTP_PORT. | true/false/(deprecated: auto) | auto
 WEB_HTTP_PORT | The port to serve the HTTP traffic or redirect from | 0-65535 | 80
 WEB_HTTPS | Whether to support HTTPS traffic on the WEB_HTTPS_PORT | true/false | true
 WEB_HTTPS_PORT | The port to serve the HTTPS traffic from | 0-65535 | 443
 WEB_HTTPS_OFFLOADED | Whether the HTTPS traffic has been forwarded without SSL | true/false | false
+WEB_HTTPS_ONLY      | Whether to redirect all HTTP traffic to HTTPS | true/false | $WEB_HTTPS (deprecated: if $WEB_HTTPS=true then false)
 WEB_REVERSE_PROXIED | Whether to interpret X-Forwarded-Proto as the $custom_scheme and $custom_https emulation. | true/false | $WEB_HTTPS_OFFLOADED
 WEB_SSL_FULLCHAIN | The location of the SSL certificate and intermediate chain file | absolute filename | /etc/ssl/certs/fullchain.pem
 WEB_SSL_PRIVKEY | The location of the SSL private key file | absolute filename | /etc/ssl/private/privkey.pem

--- a/nginx/etc/confd/templates/nginx/site.conf.tmpl
+++ b/nginx/etc/confd/templates/nginx/site.conf.tmpl
@@ -1,8 +1,8 @@
 server {
     server_name _;
+{{ if ne "false" (getenv "WEB_HTTP") }}
     listen {{ getenv "WEB_HTTP_PORT" }} default_server;
-{{ if eq "true" (getenv "WEB_HTTPS") }}
-{{ if ne "true" (getenv "WEB_HTTP") }}
+{{ if and (eq "true" (getenv "WEB_HTTPS_ONLY")) (ne "true" (getenv "WEB_REVERSE_PROXIED")) }}
 
     access_log off;
     rewrite ^ https://$host$request_uri? permanent;
@@ -10,7 +10,8 @@ server {
 
 server {
     server_name _;
-{{ end }}
+{{ end }}{{ end }}
+{{ if eq "true" (getenv "WEB_HTTPS") }}
 {{ if eq "true" (getenv "WEB_HTTPS_OFFLOADED") }}
     listen {{ getenv "WEB_HTTPS_PORT" }} default_server;{{ else }}
     listen {{ getenv "WEB_HTTPS_PORT" }} default_server ssl http2;

--- a/nginx/etc/confd/templates/nginx/site_redirect_to_https.conf.tmpl
+++ b/nginx/etc/confd/templates/nginx/site_redirect_to_https.conf.tmpl
@@ -1,4 +1,4 @@
-{{ if eq "true" (getenv "WEB_REVERSE_PROXIED") }}
+{{ if eq "true" (getenv "WEB_HTTPS_ONLY") }}
   if ($custom_scheme = 'https') {
     set $do_https_redirect 0;
   }

--- a/nginx/usr/local/share/env/55-stack
+++ b/nginx/usr/local/share/env/55-stack
@@ -4,3 +4,9 @@
 if ! [[ "$WEB_DIRECTORY" =~ ^/ ]]; then
   export WEB_DIRECTORY=${WORK_DIRECTORY}/${WEB_DIRECTORY}
 fi
+
+if [ "${WEB_HTTP}" == "true" ]; then
+  export WEB_HTTPS_ONLY=false
+else
+  export WEB_HTTPS_ONLY=${WEB_HTTPS_ONLY:-$WEB_HTTPS}
+fi

--- a/php-nginx/README.md
+++ b/php-nginx/README.md
@@ -84,11 +84,12 @@ The following variables are supported
 Variable | Description | Expected values | Default
 --- | --- | --- | ----
 WEB_HOST | The domain of the website | a domain | localhost
-WEB_HTTP | Whether to support HTTP traffic on the WEB_HTTP_PORT. If auto, it's behaviour is the reverse setting of WEB_HTTPS, and if false, will redirect to HTTPS. | true/false/auto | auto
+WEB_HTTP | Whether to support HTTP traffic on the WEB_HTTP_PORT. | true/false/(deprecated: auto) | auto
 WEB_HTTP_PORT | The port to serve the HTTP traffic or redirect from | 0-65535 | 80
 WEB_HTTPS | Whether to support HTTPS traffic on the WEB_HTTPS_PORT | true/false | true
 WEB_HTTPS_PORT | The port to serve the HTTPS traffic from | 0-65535 | 443
 WEB_HTTPS_OFFLOADED | Whether the HTTPS traffic has been forwarded without SSL | true/false | false
+WEB_HTTPS_ONLY      | Whether to redirect all HTTP traffic to HTTPS | true/false | $WEB_HTTPS (deprecated: if $WEB_HTTPS=true then false)
 WEB_REVERSE_PROXIED | Whether to interpret X-Forwarded-Proto as the $custom_scheme and $custom_https emulation. | true/false | $WEB_HTTPS_OFFLOADED
 WEB_SSL_FULLCHAIN | The location of the SSL certificate and intermediate chain file | absolute filename | /etc/ssl/certs/fullchain.pem
 WEB_SSL_PRIVKEY | The location of the SSL private key file | absolute filename | /etc/ssl/private/privkey.pem

--- a/php-nginx/etc/confd/templates/nginx/site.conf.tmpl
+++ b/php-nginx/etc/confd/templates/nginx/site.conf.tmpl
@@ -1,8 +1,8 @@
 server {
     server_name _;
+{{ if ne "false" (getenv "WEB_HTTP") }}
     listen {{ getenv "WEB_HTTP_PORT" }} default_server;
-{{ if eq "true" (getenv "WEB_HTTPS") }}
-{{ if ne "true" (getenv "WEB_HTTP") }}
+{{ if and (eq "true" (getenv "WEB_HTTPS_ONLY")) (ne "true" (getenv "WEB_REVERSE_PROXIED")) }}
 
     access_log off;
     rewrite ^ https://$host$request_uri? permanent;
@@ -10,7 +10,8 @@ server {
 
 server {
     server_name _;
-{{ end }}
+{{ end }}{{ end }}
+{{ if eq "true" (getenv "WEB_HTTPS") }}
 {{ if eq "true" (getenv "WEB_HTTPS_OFFLOADED") }}
     listen {{ getenv "WEB_HTTPS_PORT" }} default_server;{{ else }}
     listen {{ getenv "WEB_HTTPS_PORT" }} default_server ssl http2;

--- a/php-nginx/etc/confd/templates/nginx/site_redirect_to_https.conf.tmpl
+++ b/php-nginx/etc/confd/templates/nginx/site_redirect_to_https.conf.tmpl
@@ -1,4 +1,4 @@
-{{ if eq "true" (getenv "WEB_REVERSE_PROXIED") }}
+{{ if eq "true" (getenv "WEB_HTTPS_ONLY") }}
   if ($custom_scheme = 'https') {
     set $do_https_redirect 0;
   }

--- a/php-nginx/usr/local/share/env/55-stack
+++ b/php-nginx/usr/local/share/env/55-stack
@@ -5,6 +5,12 @@ if ! [[ "$WEB_DIRECTORY" =~ ^/ ]]; then
   export WEB_DIRECTORY=${WORK_DIRECTORY}/${WEB_DIRECTORY}
 fi
 
+if [ "${WEB_HTTP}" == "true" ]; then
+  export WEB_HTTPS_ONLY=false
+else
+  export WEB_HTTPS_ONLY=${WEB_HTTPS_ONLY:-$WEB_HTTPS}
+fi
+
 DEFAULT_COMPOSER_FLAGS="--no-interaction --optimize-autoloader"
 
 if [ -z "$DEVELOPMENT_MODE" ] || [ "$DEVELOPMENT_MODE" -ne 0 ]; then


### PR DESCRIPTION
There was an issue with WEB_REVERSE_PROXIED being on making it not possible to turn off HTTPS only logic, also the implicitness of WEB_HTTP=auto/true handling was confusing people.

In addition the separation makes it possible to fully turn off the http port.

The functionality over WEB_HTTP=auto/true is now deprecated but continues to function as before for BC (true turning off HTTPs redirect)