### PR TITLE
Fix resetting of scheme/http.

### DIFF
--- a/nginx/etc/confd/templates/nginx/site_custom_scheme_flags.conf.tmpl
+++ b/nginx/etc/confd/templates/nginx/site_custom_scheme_flags.conf.tmpl
@@ -8,8 +8,6 @@ if ($server_port = {{ getenv "WEB_HTTPS_PORT" }} ) {
 }{{ end }}
 
 {{ if eq "true" (getenv "WEB_REVERSE_PROXIED") }}
-set $custom_https '';
-set $custom_scheme http;
 if ($http_x_forwarded_proto) {
     set $custom_scheme $http_x_forwarded_proto;
 }

--- a/php-nginx/etc/confd/templates/nginx/site_custom_scheme_flags.conf.tmpl
+++ b/php-nginx/etc/confd/templates/nginx/site_custom_scheme_flags.conf.tmpl
@@ -8,8 +8,6 @@ if ($server_port = {{ getenv "WEB_HTTPS_PORT" }} ) {
 }{{ end }}
 
 {{ if eq "true" (getenv "WEB_REVERSE_PROXIED") }}
-set $custom_https '';
-set $custom_scheme http;
 if ($http_x_forwarded_proto) {
     set $custom_scheme $http_x_forwarded_proto;
 }


### PR DESCRIPTION
Rendered template was:
```
root@00b4b14d243b:/# cat /etc/nginx/sites-available/default-05-custom_scheme_flags.conf
set $custom_https $https;
set $custom_scheme $scheme;




set $custom_https '';
set $custom_scheme http;
if ($http_x_forwarded_proto) {
    set $custom_scheme $http_x_forwarded_proto;
}

if ($http_x_forwarded_proto = https) {
    set $custom_https on;
}
```

which leads to a redirect loop due to /etc/nginx/sites-available/default-06-site_redirect_to_https.conf containing:
```
  if ($custom_scheme = 'https') {
    set $do_https_redirect 0;
  }

  if ($do_https_redirect != 0) {
    rewrite ^ https://$host$request_uri? permanent;
  }
```