### PR TITLE
Error and quit if an unset variable is used in functions.

### DIFF
--- a/ubuntu/16.04/usr/local/bin/container
+++ b/ubuntu/16.04/usr/local/bin/container
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -e -u
 
 TASK=$1
 ARGS=( "$@" )


### PR DESCRIPTION
Helps avoid `rm -rf ${VAR}/*` wiping /* if $VAR is not set, as it could wipe out mountpoints.

A few variables such as GITHUB_TOKEN are impacted, this PR will gradually build over time to ensure variables are declared before being used.