### PR TITLE
Kill supervisord when managed processes enter FATAL state

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -11,7 +11,7 @@ fi
 docker pull koalaman/shellcheck
 docker pull lukasmartinelli/hadolint
 
-find "$DIR" -type f ! -path "*.git/*" \( \
+find "$DIR" -type f ! -path "*.git/*" ! -name "*.py" \( \
   -perm +111 -or -name "*.sh" -or -wholename "*usr/local/share/env/*" -or -wholename "*usr/local/share/container/*" \
 \) | while read -r script; do
   echo "Linting '$script':";

--- a/ubuntu/16.04/etc/supervisor/conf.d/kill_supervisord_upon_fatal_process_state.conf
+++ b/ubuntu/16.04/etc/supervisor/conf.d/kill_supervisord_upon_fatal_process_state.conf
@@ -1,0 +1,3 @@
+[eventlistener:kill_supervisord_upon_fatal_process_state]
+command=/usr/local/share/supervisord/kill_supervisord_upon_fatal_process_state.py
+events=PROCESS_STATE

--- a/ubuntu/16.04/etc/supervisor/conf.d/kill_supervisord_upon_fatal_process_state.conf
+++ b/ubuntu/16.04/etc/supervisor/conf.d/kill_supervisord_upon_fatal_process_state.conf
@@ -1,3 +1,6 @@
 [eventlistener:kill_supervisord_upon_fatal_process_state]
 command=/usr/local/share/supervisord/kill_supervisord_upon_fatal_process_state.py
-events=PROCESS_STATE
+events=PROCESS_STATE_FATAL
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+loglevel=warn

--- a/ubuntu/16.04/usr/local/share/supervisord/kill_supervisord_upon_fatal_process_state.py
+++ b/ubuntu/16.04/usr/local/share/supervisord/kill_supervisord_upon_fatal_process_state.py
@@ -1,0 +1,32 @@
+#!env python
+
+import sys
+
+def write_stdout(s):
+    # only eventlistener protocol messages may be sent to stdout
+    sys.stdout.write(s)
+    sys.stdout.flush()
+
+def write_stderr(s):
+    sys.stderr.write(s)
+    sys.stderr.flush()
+
+def main():
+    while 1:
+        # transition from ACKNOWLEDGED to READY
+        write_stdout('READY\n')
+
+        # read header line and print it to stderr
+        line = sys.stdin.readline()
+        write_stderr(line)
+
+        # read event payload and print it to stderr
+        headers = dict([ x.split(':') for x in line.split() ])
+        data = sys.stdin.read(int(headers['len']))
+        write_stderr(data)
+
+        # transition from READY to ACKNOWLEDGED
+        write_stdout('RESULT 2\nOK')
+
+if __name__ == '__main__':
+    main()

--- a/ubuntu/16.04/usr/local/share/supervisord/kill_supervisord_upon_fatal_process_state.py
+++ b/ubuntu/16.04/usr/local/share/supervisord/kill_supervisord_upon_fatal_process_state.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import sys
+from subprocess import call
 
 def write_stdout(s):
     # only eventlistener protocol messages may be sent to stdout
@@ -24,6 +25,8 @@ def main():
         headers = dict([ x.split(':') for x in line.split() ])
         data = sys.stdin.read(int(headers['len']))
         write_stderr(data)
+
+        call(["pkill", "--signal", "SIGTERM", "supervisord"])
 
         # transition from READY to ACKNOWLEDGED
         write_stdout('RESULT 2\nOK')

--- a/ubuntu/16.04/usr/local/share/supervisord/kill_supervisord_upon_fatal_process_state.py
+++ b/ubuntu/16.04/usr/local/share/supervisord/kill_supervisord_upon_fatal_process_state.py
@@ -1,4 +1,4 @@
-#!env python
+#!/usr/bin/env python
 
 import sys
 


### PR DESCRIPTION
Kill the supervisord process with a SIGTERM if a process it manages enters the fatal state, which means it didn't manage to start up successfully at all.

Tested with the following conf file `ubuntu/16.04/etc/supervisor/conf.d/test.conf`:
```
[program:test]
command = /bin/false
stdout_logfile=/dev/stdout
stdout_logfile_maxbytes=0
stderr_logfile=/dev/stderr
stderr_logfile_maxbytes=0
loglevel = warn
user = root
autostart = true
autorestart = true
priority = 5
```