### PR TITLE
Fix drupal php 7.0 build not working on CP.

### DIFF
--- a/continuous-pipe.yml
+++ b/continuous-pipe.yml
@@ -83,7 +83,7 @@ tasks:
         drupal_php71_apache:
           image: quay.io/continuouspipe/drupal-php7.1-apache
           tag: latest
-        drupal_php7_apache:
+        drupal_php70_apache:
           image: quay.io/continuouspipe/drupal-php7-apache
           tag: latest
         drupal8_apache_php7:


### PR DESCRIPTION
cp.yml did not match docker-compose.yml for this service, so CP didn't know which Dockerfile to build.