### PR TITLE
Increase fastcgi buffer settings for magento2 image.

### DIFF
--- a/magento2-nginx/fpm-7.0/etc/confd/templates/nginx/site_phpfpm.conf.tmpl
+++ b/magento2-nginx/fpm-7.0/etc/confd/templates/nginx/site_phpfpm.conf.tmpl
@@ -2,13 +2,19 @@
 location ~ (index|get|static|report|404|503)\.php$ {
     try_files $uri =404;
     fastcgi_pass    php-fpm;
-    fastcgi_buffers 1024 4k;
 
     fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
     fastcgi_param  PHP_VALUE "memory_limit=768M \n max_execution_time=600";
 
     fastcgi_read_timeout 600s;
     fastcgi_connect_timeout 600s;
+
+    fastcgi_send_timeout 7200;
+    fastcgi_read_timeout 7200;
+    fastcgi_buffer_size 128k;
+    fastcgi_buffers 1024 4k;
+    fastcgi_busy_buffers_size 1024k;
+    fastcgi_temp_file_write_size 1024k;
     fastcgi_param  MAGE_MODE $MAGE_MODE;
 
     fastcgi_index  index.php;


### PR DESCRIPTION
Magento 2 sends a lot of cookies when logging in, etc.  We need to be able to handle that in our fastcgi settings.