### PR TITLE
add piwik

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ internal services and for the application templates.
     - [NGINX w/ PHP-FPM 7.0](magento2-nginx/fpm-7.0/)
     - [Varnish](magento2-varnish/4.0/)
 - [Symfony - NGINX or Apache with PHP 5.6, 7.0 or 7.1)](symfony/)
+- [Piwik](piwik/)
 
 ### Web Applications
 

--- a/continuous-pipe.yml
+++ b/continuous-pipe.yml
@@ -171,6 +171,9 @@ tasks:
         phantomjs2:
           image: quay.io/continuouspipe/phantomjs2
           tag: latest
+        piwik_php71_apache:
+          image: quay.io/continuouspipe/piwik-php7.1-apache
+          tag: latest
         redis:
           image: quay.io/continuouspipe/redis3
           tag: latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -191,6 +191,14 @@ services:
     depends_on:
       - ubuntu
 
+  piwik_php71_apache:
+    build:
+      context: ./piwik/
+      dockerfile: Dockerfile-php7.1
+    image: quay.io/continuouspipe/piwik-php7.1-apache:latest
+    depends_on:
+      - php71_apache
+
   php71_apache:
     build:
       context: ./php-apache/

--- a/piwik/Dockerfile-php7.1
+++ b/piwik/Dockerfile-php7.1
@@ -1,0 +1,13 @@
+FROM quay.io/continuouspipe/php7.1-apache:latest
+
+MAINTAINER Alex Biddle <alex.biddle+cp-dockerfiles@inviqa.com>
+
+WORKDIR /app/web/piwik
+RUN curl -L -O https://builds.piwik.org/latest.tar.gz && \
+    tar --strip 1 -xzf latest.tar.gz && \
+    rm latest.tar.gz
+
+RUN chown -R build:www-data ./*
+RUN chmod -R 0755 ./*
+RUN chmod -R 0775 tmp \
+    config

--- a/piwik/README.md
+++ b/piwik/README.md
@@ -1,0 +1,31 @@
+# Piwik
+
+In a docker-compose.yml:
+```yml
+version: '3'
+services:
+  piwik:
+    image: quay.io/continuouspipe/piwik-php7.1-apache:stable
+```
+
+In a Dockerfile:
+```Dockerfile
+FROM quay.io/continuouspipe/piwik-php7.1-apache:stable
+```
+
+## How to build
+```bash
+docker-compose build piwik_php71_apache
+docker-compose push piwik_php71_apache
+```
+
+## About
+
+This is an image that installs [piwik](http://piwik.org) web analytics software.
+
+
+### Environment variables
+
+No additional environment variables over those of continuouspipe/php7.1-apache are supported, as piwik at this time does not support headless installations.
+
+


### PR DESCRIPTION
Add piwik installation to CP

Test with composer file (not linked to db at moment, you can just see the installation screen)

````version: '2'
services:
  web:
    image: quay.io/continuouspipe/piwik-php7.1-apache:latest
    ports:
    - '443:443'