### PR TITLE
fix syntax in nginx-reverse-proxy/README.md

### DIFF
--- a/nginx-reverse-proxy/README.md
+++ b/nginx-reverse-proxy/README.md
@@ -9,7 +9,7 @@ services:
     depends_on:
      - web
     environment:
-      PROXY_LOCATIONS: '[{"location": "/", backend: "https://web", "preserve_host": true}, {"location": "~ /foo(/|$)", backend: "https://web/bar", "preserve_host": true}]'
+      PROXY_LOCATIONS: '[{"location": "/", "backend": "https://web", "preserve_host": true}, {"location": "~ /foo(/|$)", "backend": "https://web/bar", "preserve_host": true}]'
   web:
     image: ...
 ```


### PR DESCRIPTION
Just a small fix to the README to quote backend.