### PR TITLE
Fix Drupal apache vhost by adding a comment to the drupal AllowOverride line.

### DIFF
--- a/drupal/etc/confd/templates/apache/site_base.conf.tmpl
+++ b/drupal/etc/confd/templates/apache/site_base.conf.tmpl
@@ -2,6 +2,7 @@ DocumentRoot {{ getenv "WEB_DIRECTORY" }}
 
 <Directory {{ getenv "WEB_DIRECTORY" }}>
     Options FollowSymLinks
+    # Use the .htaccess provided by Drupal (for now)
     AllowOverride All
     Require all granted
 </Directory>


### PR DESCRIPTION
Without a comment or more major change in content, docker isn't picking this up as a new file
version, so only the homepage of a drupal site works!