### PR TITLE
Fix development_start not working for magento1

### DIFF
--- a/ubuntu/16.04/usr/local/share/container/baseimage-10.sh
+++ b/ubuntu/16.04/usr/local/share/container/baseimage-10.sh
@@ -12,8 +12,8 @@ alias_function do_start do_ubuntu_start_inner
 do_start() {
     do_ubuntu_start_inner
     do_update_permissions
-    check_development_start
     do_templating
+    check_development_start
 }
 
 alias_function do_build do_ubuntu_build_inner


### PR DESCRIPTION
 Dev tools need templates put in place first.