### PR TITLE
Remove drupal init as it needs a codebase to run "init" within.

### DIFF
--- a/drupal/Dockerfile-php5.6
+++ b/drupal/Dockerfile-php5.6
@@ -22,10 +22,7 @@ USER build
 
 # Install Drupal's Drush tool
 RUN composer global require drush/drush:~8.1.10 \
- && composer global clear-cache \
- \
- # Initialise Drupal CLI tool \
- && /usr/local/bin/drupal init --no-interaction
+ && composer global clear-cache
 
 USER root
 

--- a/drupal/Dockerfile-php7
+++ b/drupal/Dockerfile-php7
@@ -22,10 +22,7 @@ USER build
 
 # Install Drupal's Drush tool
 RUN composer global require drush/drush:~8.1.10 \
- && composer global clear-cache \
- \
- # Initialise Drupal CLI tool \
- && /usr/local/bin/drupal init --no-interaction
+ && composer global clear-cache
 
 USER root
 

--- a/drupal/Dockerfile-php7.1
+++ b/drupal/Dockerfile-php7.1
@@ -22,10 +22,7 @@ USER build
 
 # Install Drupal's Drush tool
 RUN composer global require drush/drush:~8.1.10 \
- && composer global clear-cache \
- \
- # Initialise Drupal CLI tool \
- && /usr/local/bin/drupal init --no-interaction
+ && composer global clear-cache
 
 USER root
 

--- a/drupal/Dockerfile.tmpl
+++ b/drupal/Dockerfile.tmpl
@@ -22,10 +22,7 @@ USER build
 
 # Install Drupal's Drush tool
 RUN composer global require drush/drush:~8.1.10 \
- && composer global clear-cache \
- \
- # Initialise Drupal CLI tool \
- && /usr/local/bin/drupal init --no-interaction
+ && composer global clear-cache
 
 USER root
 


### PR DESCRIPTION
Due to `You must execute the launcher within a drupal site directory or use --root=/path/to/drupal8.dev to specify your drupal site path.` on https://docs.drupalconsole.com/en/getting/launcher.html

This is new and wasn't in older versions of the drupal console tool.