### PR TITLE
Make the container's plan.sh more accessible to projects

### DIFF
--- a/ubuntu/16.04/README.md
+++ b/ubuntu/16.04/README.md
@@ -191,7 +191,7 @@ As such, only set APP_USER_LOCAL in development when using volumes.
 ### Custom build and startup scripts
 
 To run commands during the build and startup sequences that the base images add,
-please add `usr/local/share/container/plan.sh` for a project, or
+please add `/app/plan.sh` for a project, or
 `usr/local/share/container/baseimage-{number}.sh` if creating another base image.
 
 This allows you to define and override bash functions that the base images add.

--- a/ubuntu/16.04/usr/local/bin/container
+++ b/ubuntu/16.04/usr/local/bin/container
@@ -18,6 +18,10 @@ if [ "$#" -gt 0 ]; then
 fi
 
 source /usr/local/share/container/plan.sh
+if [ -x "$WORK_DIRECTORY/plan.sh" ]; then
+  # shellcheck source=/dev/null
+  source "$WORK_DIRECTORY/plan.sh"
+fi
 
 set -x
 


### PR DESCRIPTION
This allows applications to write the plan.sh in their project root path, and it get's copied in along with their project code.

Additionally cp-remote watch and local docker mounts will sync edits to it to the container, allowing realtime usage of the plan.sh functions and overrides without a new build or editing within the container.