### PR TITLE
Highly available redis3 with customisable master failover timeout

### DIFF
--- a/continuous-pipe.yml
+++ b/continuous-pipe.yml
@@ -183,6 +183,9 @@ tasks:
         redis:
           image: quay.io/continuouspipe/redis3
           tag: latest
+        redis_highly_available:
+          image: quay.io/continuouspipe/redis3-highly-available
+          tag: latest
         scala_sbt:
           image: quay.io/continuouspipe/scala-base
           tag: latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -267,7 +267,7 @@ services:
     image: quay.io/continuouspipe/php5.6-nginx:latest
     depends_on:
       - ubuntu
-      
+
   scala_sbt:
     build:
       context: ./scala-base/1.0/
@@ -281,6 +281,13 @@ services:
     image: quay.io/continuouspipe/redis3:latest
     depends_on:
       - external_redis
+
+  redis_highly_available:
+    build:
+      context: ./redis/3-highly-available/
+    image: quay.io/continuouspipe/redis3-highly-available:latest
+    depends_on:
+      - external_redis_highly_available
 
   elasticsearch:
     build:
@@ -398,6 +405,9 @@ services:
 
   external_redis:
     image: redis:3.2
+
+  external_redis_highly_available:
+    image: gcr.io/google_containers/redis:v1
 
   external_elasticsearch:
     image: elasticsearch:2.4

--- a/redis/3-highly-available/Dockerfile
+++ b/redis/3-highly-available/Dockerfile
@@ -2,5 +2,16 @@ FROM gcr.io/google_containers/redis:v1
 
 MAINTAINER "Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>"
 
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -s dist-upgrade | grep "^Inst" | \
+      grep -i securi | awk -F " " '{print $2}' | \
+      xargs apt-get -qq -y --no-install-recommends install \
+ && apt-get upgrade -qq -y dpkg openldap \
+ \
+ # Clean the image \
+ && apt-get autoremove -qq \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
+
 ENV REDIS_MASTER_DOWN_AFTER_MILLISECONDS=5000
 RUN sed -i'' 's/sentinel down-after-milliseconds mymaster 60000/sentinel down-after-milliseconds mymaster ${REDIS_MASTER_DOWN_AFTER_MILLISECONDS}/' /run.sh

--- a/redis/3-highly-available/Dockerfile
+++ b/redis/3-highly-available/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/google_containers/redis:v1
+
+MAINTAINER "Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>"
+
+ENV REDIS_MASTER_DOWN_AFTER_MILLISECONDS=5000
+RUN sed -i'' 's/sentinel down-after-milliseconds mymaster 60000/sentinel down-after-milliseconds mymaster ${REDIS_MASTER_DOWN_AFTER_MILLISECONDS}/' /run.sh

--- a/redis/3-highly-available/Dockerfile
+++ b/redis/3-highly-available/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -qq \
  # Clean the image \
  && apt-get autoremove -qq \
  && apt-get clean \
- && rm -rf /var/lib/apt/lists/* \
+ && rm -rf /var/lib/apt/lists/*
 
 ENV REDIS_MASTER_DOWN_AFTER_MILLISECONDS=5000
 RUN sed -i'' 's/sentinel down-after-milliseconds mymaster 60000/sentinel down-after-milliseconds mymaster ${REDIS_MASTER_DOWN_AFTER_MILLISECONDS}/' /run.sh

--- a/redis/3-highly-available/Dockerfile
+++ b/redis/3-highly-available/Dockerfile
@@ -6,7 +6,6 @@ RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -s dist-upgrade | grep "^Inst" | \
       grep -i securi | awk -F " " '{print $2}' | \
       xargs apt-get -qq -y --no-install-recommends install \
- && apt-get upgrade -qq -y dpkg openldap \
  \
  # Clean the image \
  && apt-get autoremove -qq \

--- a/redis/3-highly-available/README.md
+++ b/redis/3-highly-available/README.md
@@ -1,0 +1,35 @@
+# Highly available Redis 3
+
+In a Dockerfile:
+```Dockerfile
+FROM quay.io/continuouspipe/redis3-highly-available:stable
+```
+
+In a docker-compose.yml:
+```yml
+version: '3'
+services:
+  redis:
+    image: quay.io/continuouspipe/redis3-highly-available:stable
+```
+
+## How to build
+```bash
+docker-compose build redis_highly_available
+docker-compose push redis_highly_available
+```
+
+## About
+
+Based on https://github.com/kubernetes/kubernetes/blob/master/examples/storage/redis/ but supporting the customisation
+of the timeout for triggering a master failover.
+
+## How to use
+
+### Environment variables
+
+The following variables are supported
+
+Variable | Description | Expected values | Default
+--- | --- | --- | ----
+REDIS_MASTER_DOWN_AFTER_MILLISECONDS | How many milliseconds to wait before starting a master failover (if two or more redis sentinels agree) | integer (milliseconds) | 5000

--- a/test.sh
+++ b/test.sh
@@ -21,6 +21,6 @@ done
 
 find "$DIR" -type f -name "Dockerfile" | while read -r dockerfile; do
   echo "Linting '$dockerfile':";
-  docker run --rm -i lukasmartinelli/hadolint hadolint --ignore DL3008 --ignore DL3002 --ignore DL4001 --ignore DL3007 - < "$dockerfile"
+  docker run --rm -i lukasmartinelli/hadolint hadolint --ignore DL3008 --ignore DL3002 --ignore DL4001 --ignore DL3007 --ignore SC2016 - < "$dockerfile"
   echo
 done


### PR DESCRIPTION
Based on a Google image built from alpine.

Image source is available here: https://github.com/kubernetes/kubernetes/blob/master/examples/storage/redis/image/

We were seeing failovers in a redis cluster take 60 seconds to detect, which is the setting in the run.sh from the kubernetes/kubernetes link above.
We have therefore allowed customisation and defaulted to a lower amount of time as per the tutorial on https://redis.io/topics/sentinel#a-quick-tutorial