### PR TITLE
Use all X-Forwarded-* headers by default

### DIFF
--- a/nginx-reverse-proxy/README.md
+++ b/nginx-reverse-proxy/README.md
@@ -47,7 +47,31 @@ export PROXY_LOCATIONS='[
 Multiple locations can be specified. The only required keys per location are
 location and backend.
 
+Location settings available:
+
+Key | Description | Expected values | Default
+--- | --- | --- | ---
+location | The domain-relative uri for which to apply the proxy configuration | domain-relative uri |
+backend | The backend host to proxy for the location, note for domains, WEB_RESOLVER needs to be set | url |
+preserve_host | Whether to pass the request's HTTP Host header value, or otherwise use the host from the backend setting | true/false | false
+use_downstream_edge_headers | Whether to pass the downstream edge headers to the backend server, or send it's own | true/false | false
+hide_edge_headers | Whether to hide edge headers from the backend server | true/false | false
+
 As this is using NGINX's proxy module, check out the documentation here: https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_pass
+
+### Edge vs intermediate reverse proxy header handling
+
+Edge and intermediate reverse proxies should handle X-Forwarded-* headers differently.
+
+Other than X-Forwarded-For, generally edge servers should ignore downstream
+X-Forwarded-* headers as they are untrusted, yet intermediate servers may need
+to proxy downstream X-Forwarded-* headers, if the edge servers set them.
+
+This can be achieved by setting `use_downstream_edge_headers` to true for
+intermediate servers, and false (which is the default) for edge servers.
+
+X-Forwarded-For instead is fine the same for both, as it appends the next value
+onto the end of the existing header value.
 
 ### SSL Certificates/key
 

--- a/nginx-reverse-proxy/etc/confd/templates/nginx/site_base.conf.tmpl
+++ b/nginx-reverse-proxy/etc/confd/templates/nginx/site_base.conf.tmpl
@@ -3,8 +3,18 @@
 location {{ .location }} {
   proxy_pass {{ .backend }};
   proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+{{ if .hide_edge_headers }}
+  proxy_set_header X-Forwarded-Proto "";
+  proxy_set_header X-Forwarded-Host "";
+  proxy_set_header X-Forwarded-Port "";
+{{ else }}
+  {{ if not .use_downstream_edge_headers }}
   proxy_set_header X-Forwarded-Proto $custom_scheme;
-{{ if (.preserve_host) }}
+  proxy_set_header X-Forwarded-Host $host;
+  proxy_set_header X-Forwarded-Port $server_port;
+  {{ end }}
+{{ end }}
+{{ if .preserve_host }}
   proxy_set_header Host $host;{{ end }}
 {{ range $key, $value := .server_params }}
   {{ $key }} {{ $value }};{{ end }}

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -70,6 +70,7 @@ WEB_HTTPS | Whether to support HTTPS traffic on the WEB_HTTPS_PORT | true/false 
 WEB_HTTPS_PORT | The port to serve the HTTPS traffic from | 0-65535 | 443
 WEB_HTTPS_OFFLOADED | Whether the HTTPS traffic has been forwarded without SSL to the HTTPS port | true/false | false
 WEB_HTTPS_ONLY      | Whether to redirect all HTTP traffic to HTTPS | true/false | $WEB_HTTPS (deprecated: if $WEB_HTTPS=true then false)
+WEB_RESOLVER        | DNS resolver for proxy_pass and ssl_stapling_verify | ip address |
 WEB_REVERSE_PROXIED | Whether to interpret X-Forwarded-Proto as the $custom_scheme and $custom_https emulation. | true/false | true
 WEB_SSL_CIPHERS | The enabled SSL/TLS server ciphers | the format understood by the OpenSSL library | ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS
 WEB_SSL_FULLCHAIN | The location of the SSL certificate and intermediate chain file | absolute filename | /etc/ssl/certs/fullchain.pem

--- a/nginx/etc/confd/conf.d/nginx_core.conf.toml
+++ b/nginx/etc/confd/conf.d/nginx_core.conf.toml
@@ -1,0 +1,6 @@
+[template]
+src   = "nginx/nginx_core.conf.tmpl"
+dest  = "/etc/nginx/conf.d/nginx_core.conf"
+mode  = "0644"
+keys = [
+]

--- a/nginx/etc/confd/templates/nginx/nginx_core.conf.tmpl
+++ b/nginx/etc/confd/templates/nginx/nginx_core.conf.tmpl
@@ -1,0 +1,3 @@
+{{ if getenv "WEB_RESOLVER" }}
+resolver {{ getenv "WEB_RESOLVER" }};
+{{ end }}


### PR DESCRIPTION
Some applications (e.g. Symfony) implicitly trust other X-Forwarded-* headers if they are sent from a trusted proxy. This means they can be manipulated by the user if not set or cleared.

Therefore a new "edge_headers" location setting, defaulting to true, can be used to say which trusted proxy is considered the edge server, and a new "hide_edge_headers" location setting to unset any earlier trusted proxy headers, when it's known there are none or not supplied.

X-Forwarded-For isn't just an edge header but a full chain, so it should be set whatever the case.

Sadly this wont cater to every reverse proxy situation, but is the best fit for most.