### PR TITLE
Install security updates to SOLR 4 and 6 images.

### DIFF
--- a/solr/4.10/Dockerfile
+++ b/solr/4.10/Dockerfile
@@ -4,6 +4,16 @@ MAINTAINER Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>
 
 USER root
 
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -s dist-upgrade | grep "^Inst" | \
+      grep -i securi | awk -F " " '{print $2}' | \
+      xargs apt-get -qq -y --no-install-recommends install \
+ \
+ # Clean the image \
+ && apt-get autoremove -qq \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY ./usr/ /usr
 
 CMD ["/bin/bash", "-c", "/usr/local/share/solr/startup.sh"]

--- a/solr/6.2/Dockerfile
+++ b/solr/6.2/Dockerfile
@@ -2,4 +2,18 @@ FROM solr:6.2
 
 MAINTAINER Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>
 
+USER root
+
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -s dist-upgrade | grep "^Inst" | \
+      grep -i securi | awk -F " " '{print $2}' | \
+      xargs apt-get -qq -y --no-install-recommends install \
+ \
+ # Clean the image \
+ && apt-get autoremove -qq \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+USER solr
+
 COPY ./docker-entrypoint-initdb.d/ /docker-entrypoint-initdb.d


### PR DESCRIPTION
Hoping to see some improvement to the security scan on https://quay.io/repository/continuouspipe/solr4?tab=tags and https://quay.io/repository/continuouspipe/solr6?tab=tags 