### PR TITLE
Install security updates to elasticsearch image

### DIFF
--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,3 +1,13 @@
 FROM elasticsearch:2.4
 
 MAINTAINER "Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>"
+
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -s dist-upgrade | grep "^Inst" | \
+      grep -i securi | awk -F " " '{print $2}' | \
+      xargs apt-get -qq -y --no-install-recommends install \
+ \
+ # Clean the image \
+ && apt-get autoremove -qq \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Hoping to see an improvement to the security scan results on https://quay.io/repository/continuouspipe/elasticsearch2.4?tab=tags