### PR TITLE
Install security updates to mongodb image.

### DIFF
--- a/mongodb/Dockerfile-3.4
+++ b/mongodb/Dockerfile-3.4
@@ -2,6 +2,16 @@ FROM mongo:3.4
 
 MAINTAINER "Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>"
 
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -s dist-upgrade | grep "^Inst" | \
+      grep -i securi | awk -F " " '{print $2}' | \
+      xargs apt-get -qq -y --no-install-recommends install \
+ \
+ # Clean the image \
+ && apt-get autoremove -qq \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY ./usr/ /usr
 
 CMD ["/usr/local/bin/mongo-init.sh"]

--- a/mongodb/Dockerfile.tmpl
+++ b/mongodb/Dockerfile.tmpl
@@ -2,6 +2,16 @@ FROM mongo:{{IMAGE_TAG}}
 
 MAINTAINER "Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>"
 
+RUN apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -s dist-upgrade | grep "^Inst" | \
+      grep -i securi | awk -F " " '{print $2}' | \
+      xargs apt-get -qq -y --no-install-recommends install \
+ \
+ # Clean the image \
+ && apt-get autoremove -qq \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
 COPY ./usr/ /usr
 
 CMD ["/usr/local/bin/mongo-init.sh"]


### PR DESCRIPTION
Whilst :latest is up to date regarding fixable security problems, this should help us in the future.
https://quay.io/repository/continuouspipe/mongodb3.4?tab=tags