### PR TITLE
Add NodeJS 8 image.

### DIFF
--- a/continuous-pipe.yml
+++ b/continuous-pipe.yml
@@ -174,6 +174,20 @@ tasks:
               value: "7.x"
             - name: INSTALL_COMMON_PACKAGES
               value: "false"
+        nodejs8:
+          image: quay.io/continuouspipe/nodejs8
+          tag: latest
+          environment:
+            - name: NODE_VERSION
+              value: "8.x"
+        nodejs8_small:
+          image: quay.io/continuouspipe/nodejs8-small
+          tag: latest
+          environment:
+            - name: NODE_VERSION
+              value: "8.x"
+            - name: INSTALL_COMMON_PACKAGES
+              value: "false"
         phantomjs2:
           image: quay.io/continuouspipe/phantomjs2
           tag: latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,6 +200,25 @@ services:
     depends_on:
       - ubuntu
 
+  nodejs8:
+    build:
+      context: ./nodejs/
+      args:
+        NODE_VERSION: "8.x"
+    image: quay.io/continuouspipe/nodejs8:latest
+    depends_on:
+      - ubuntu
+
+  nodejs8_small:
+    build:
+      context: ./nodejs/
+      args:
+        NODE_VERSION: "8.x"
+        INSTALL_COMMON_PACKAGES: "false"
+    image: quay.io/continuouspipe/nodejs8-small:latest
+    depends_on:
+      - ubuntu
+
   phantomjs2:
     build: ./phantomjs
     image: quay.io/continuouspipe/phantomjs2:latest


### PR DESCRIPTION
Add a NodeJS 8.x image, which will become the latest stable later this year.
Repos and build permissions updated in Quay already.