### PR TITLE
Allow longer domain names in NGINX

### DIFF
--- a/nginx/etc/confd/conf.d/nginx_server_name_bucket_size.conf.toml
+++ b/nginx/etc/confd/conf.d/nginx_server_name_bucket_size.conf.toml
@@ -1,0 +1,6 @@
+[template]
+src   = "nginx/nginx_server_name_bucket_size.conf.tmpl"
+dest  = "/etc/nginx/conf.d/nginx_server_name_bucket_size.conf"
+mode  = "0644"
+keys = [
+]

--- a/nginx/etc/confd/templates/nginx/nginx_server_name_bucket_size.tmpl
+++ b/nginx/etc/confd/templates/nginx/nginx_server_name_bucket_size.tmpl
@@ -1,0 +1,3 @@
+server_names_hash_max_size      16;
+server_names_hash_bucket_size   128;
+map_hash_bucket_size            128;

--- a/php-nginx/etc/confd/conf.d/nginx_server_name_bucket_size.conf.toml
+++ b/php-nginx/etc/confd/conf.d/nginx_server_name_bucket_size.conf.toml
@@ -1,0 +1,6 @@
+[template]
+src   = "nginx/nginx_server_name_bucket_size.conf.tmpl"
+dest  = "/etc/nginx/conf.d/nginx_server_name_bucket_size.conf"
+mode  = "0644"
+keys = [
+]

--- a/php-nginx/etc/confd/templates/nginx/nginx_server_name_bucket_size.conf.tmpl
+++ b/php-nginx/etc/confd/templates/nginx/nginx_server_name_bucket_size.conf.tmpl
@@ -1,0 +1,3 @@
+server_names_hash_max_size      16;
+server_names_hash_bucket_size   128;
+map_hash_bucket_size            128;


### PR DESCRIPTION
Avoids NGINX not starting up if given a long domain name as server_name