### PR TITLE
Tideways Daemon Image

### DIFF
--- a/continuous-pipe.yml
+++ b/continuous-pipe.yml
@@ -207,6 +207,9 @@ tasks:
         symfony_php56_apache:
           image: quay.io/continuouspipe/symfony-php5.6-apache
           tag: latest
+        tideways:
+          image: quay.io/continuouspipe/tideways
+          tag: latest
 
 notifications:
   slack_failure_notification:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -367,6 +367,13 @@ services:
     depends_on:
       - php56_apache
 
+  tideways:
+    build:
+      context: ./tideways/
+    image: quay.io/continuouspipe/tideways:latest
+    depends_on:
+      - ubuntu
+
   ubuntu:
     build:
       context: ./ubuntu/16.04/

--- a/tideways/Dockerfile
+++ b/tideways/Dockerfile
@@ -1,0 +1,16 @@
+FROM quay.io/continuouspipe/ubuntu16.04:latest
+
+MAINTAINER Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>
+
+RUN echo 'deb http://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages debian main' > /etc/apt/sources.list.d/tideways.list \
+ && curl -sS https://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages/EEB5E8F4.gpg | apt-key add - \
+ && apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
+    tideways-daemon \
+ \
+ # Clean the image \
+ && apt-get auto-remove -qq -y \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY ./etc/ /etc/

--- a/tideways/README.md
+++ b/tideways/README.md
@@ -1,0 +1,34 @@
+# Tideways Daemon
+
+In a Dockerfile:
+```Dockerfile
+FROM quay.io/continuouspipe/tideways:stable
+```
+or in a docker-compose.yml:
+```yml
+version: '3'
+services:
+  web:
+    image: quay.io/continuouspipe/php7.1-nginx:stable
+    links:
+      - tideways
+
+  tideways:
+    image: quay.io/continuouspipe/tideways:stable
+```
+
+## How to build
+```bash
+docker-compose build tideways
+docker-compose push tideways
+```
+
+## About
+
+This is a Docker image for the Tideways Daemon process. It is talked to from php-nginx and php-apache images and this
+daemon will forward the generated PHP profile logs to the Tideways API.
+
+## How to use
+
+As for all images based on the ubuntu base image, see
+[the base image README](../../ubuntu/16.04/README.md)

--- a/tideways/etc/confd/conf.d/supervisor_tideways_daemon.conf.toml
+++ b/tideways/etc/confd/conf.d/supervisor_tideways_daemon.conf.toml
@@ -1,0 +1,6 @@
+[template]
+src   = "supervisor/tideways_daemon.conf.tmpl"
+dest  = "/etc/supervisor/conf.d/tideways_daemon.conf"
+mode  = "0644"
+keys = [
+]

--- a/tideways/etc/confd/templates/supervisor/tideways_daemon.conf.tmpl
+++ b/tideways/etc/confd/templates/supervisor/tideways_daemon.conf.tmpl
@@ -1,0 +1,11 @@
+[program:tideways_daemon]
+command = /usr/bin/tideways-daemon --hostname=tideways-daemon --address=0.0.0.0:9135
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+loglevel = warn
+user = tideways
+autostart = true
+autorestart = true
+priority = 5


### PR DESCRIPTION
To forward logs from Tideways PHP extensions through to the API, deploy as a service alongside the web containers.