### PR TITLE
[RFC] Do not use root as default user [WIP]

### DIFF
--- a/ubuntu/16.04/Dockerfile
+++ b/ubuntu/16.04/Dockerfile
@@ -44,4 +44,6 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
 COPY ./etc/ /etc/
 COPY ./usr/ /usr/
 
+USER build
+
 CMD ["/usr/local/bin/container", "start_supervisord"]

--- a/ubuntu/16.04/Dockerfile
+++ b/ubuntu/16.04/Dockerfile
@@ -46,4 +46,4 @@ COPY ./usr/ /usr/
 
 USER build
 
-CMD ["/usr/local/bin/container", "start_supervisord"]
+CMD ["/usr/bin/sudo", "/usr/local/bin/container", "start_supervisord"]

--- a/ubuntu/16.04/etc/sudoers.d/build
+++ b/ubuntu/16.04/etc/sudoers.d/build
@@ -1,0 +1,1 @@
+build ALL = (ALL) NOPASSWD: ALL


### PR DESCRIPTION
Connecting to containers as root causes issues with permissions when using cp-remote to sync files, or running commands without realising.

If the build user were to be connected to instead, file permissions for new files would be correct and commands that would create new files in the wrong places (e.g. cache directories owned by www-data) would fail but not cause a site outage.

Invocations of `container` that need to do privileged things like install software with apt-get, would have to be re-run as `sudo container` instead.
This would be a breaking change as if people are using `container setup`, for example in a continuous-pipe.yml, they would need to update it to be `sudo container setup`.

Either that or we need to go around adding `sudo` to all commands we run that expected to be root before.

What do you think we should do?