### PR TITLE
Fix mailcatcher ports

### DIFF
--- a/mailcatcher/README.md
+++ b/mailcatcher/README.md
@@ -47,3 +47,10 @@ mailer_sender_mail: some@example.com
 mailer_port: 1025
 mailer_encryption: null
 ```
+
+The following variables are supported:
+
+Variable | Description | Expected values | Default
+--- | --- | --- | ----
+HTTP_HOST_PORT | The port to make the Mailcatcher UI available on | 1-65535 | 1080
+SMTP_HOST_PORT | The port to make the SMTP server available on. | 1-65535 | 1025

--- a/mailcatcher/usr/local/bin/mailcatcher.sh
+++ b/mailcatcher/usr/local/bin/mailcatcher.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
-export HTTP_PORT=${HTTP_PORT:-1080}
-export SMTP_PORT=${SMTP_PORT:-1025}
+HTTP_PORT=${HTTP_PORT:-1080}
+SMTP_PORT=${SMTP_PORT:-1025}
+if [[ "$HTTP_PORT" =~ "tcp://" ]]; then
+  HTTP_PORT="1080"
+fi
+if [[ "$SMTP_PORT" =~ "tcp://" ]]; then
+  SMTP_PORT="1025"
+fi
+export HTTP_PORT
+export SMTP_PORT
 
 exec mailcatcher --foreground --ip=0.0.0.0 "--smtp-port=$SMTP_PORT" "--http-port=$HTTP_PORT" --no-quit

--- a/mailcatcher/usr/local/bin/mailcatcher.sh
+++ b/mailcatcher/usr/local/bin/mailcatcher.sh
@@ -1,25 +1,30 @@
 #!/bin/bash
-HTTP_PORT=${HTTP_PORT:-1080}
-SMTP_PORT=${SMTP_PORT:-1025}
+
 # Work around where if there is a service named "http" or "smtp", the HTTP_PORT/SMTP_PORT will be "tcp://<ip>:<port>"
 # rather than just the port number
 if [[ "$HTTP_PORT" =~ "tcp://" ]]; then
   HTTP_PORT="1080"
 fi
+
 if [[ "$SMTP_PORT" =~ "tcp://" ]]; then
   SMTP_PORT="1025"
 fi
 
+HTTP_HOST_PORT=${HTTP_HOST_PORT:-${HTTP_PORT:-1080}}
+SMTP_HOST_PORT=${SMTP_HOST_PORT:-${SMTP_PORT:-1025}}
+
 function check_valid_port() {
   local VAR_NAME="$1"
-  local PORT="$2"
+  local PORT="${!VAR_NAME}"
   if [[ "$PORT" =~ [^0-9] ]] || [[ "$PORT" -lt 1 ]] || [[ "$PORT" -gt 65535 ]]; then
     echo "Invalid Port specified for $VAR_NAME: '$PORT'"
     exit 1
   fi
 }
 
-check_valid_port "HTTP_PORT" "$HTTP_PORT"
-check_valid_port "SMTP_PORT" "$SMTP_PORT"
+check_valid_port "HTTP_HOST_PORT"
+check_valid_port "SMTP_HOST_PORT"
+export HTTP_HOST_PORT
+export SMTP_HOST_PORT
 
 exec mailcatcher --foreground --ip=0.0.0.0 "--smtp-port=$SMTP_PORT" "--http-port=$HTTP_PORT" --no-quit

--- a/mailcatcher/usr/local/bin/mailcatcher.sh
+++ b/mailcatcher/usr/local/bin/mailcatcher.sh
@@ -1,13 +1,25 @@
 #!/bin/bash
 HTTP_PORT=${HTTP_PORT:-1080}
 SMTP_PORT=${SMTP_PORT:-1025}
+# Work around where if there is a service named "http" or "smtp", the HTTP_PORT/SMTP_PORT will be "tcp://<ip>:<port>"
+# rather than just the port number
 if [[ "$HTTP_PORT" =~ "tcp://" ]]; then
   HTTP_PORT="1080"
 fi
 if [[ "$SMTP_PORT" =~ "tcp://" ]]; then
   SMTP_PORT="1025"
 fi
-export HTTP_PORT
-export SMTP_PORT
+
+function check_valid_port() {
+  local VAR_NAME="$1"
+  local PORT="$2"
+  if [[ "$PORT" =~ [^0-9] ]] || [[ "$PORT" -lt 1 ]] || [[ "$PORT" -gt 65535 ]]; then
+    echo "Invalid Port specified for $VAR_NAME: '$PORT'"
+    exit 1
+  fi
+}
+
+check_valid_port "HTTP_PORT" "$HTTP_PORT"
+check_valid_port "SMTP_PORT" "$SMTP_PORT"
 
 exec mailcatcher --foreground --ip=0.0.0.0 "--smtp-port=$SMTP_PORT" "--http-port=$HTTP_PORT" --no-quit


### PR DESCRIPTION
Fix where if a service is called "http" or "smtp", docker/kubernetes provides the IP address of the linked service as "tcp://<ip>:<port>"