### PR TITLE
Fix template path for the protect admin feature of Magento2

### DIFF
--- a/magento2-nginx/fpm-7.0/etc/confd/conf.d/nginx_protect_admin.conf.toml
+++ b/magento2-nginx/fpm-7.0/etc/confd/conf.d/nginx_protect_admin.conf.toml
@@ -1,5 +1,5 @@
 [template]
-src   = "nginx/protect_admin.conf.tmpl"
+src   = "nginx/site_protect_admin.conf.tmpl"
 dest  = "/etc/nginx/sites-available/default-10-protect_admin.conf"
 mode  = "0644"
 keys = [


### PR DESCRIPTION
Template path didn't exist and stopped confd from starting!