### PR TITLE
Remove load from redis slaves for magento2

### DIFF
--- a/magento2-nginx/fpm-7.0/etc/confd/templates/magento/env.php.tmpl
+++ b/magento2-nginx/fpm-7.0/etc/confd/templates/magento/env.php.tmpl
@@ -18,7 +18,6 @@ return array (
                                     'timeout' => '0.5',
                                     'sentinel_master' => '{{ getenv "REDIS_SENTINEL_MASTER" }}',
                                     'sentinel_master_verify' => '1',
-                                    'load_from_slaves' => '2',
 {{ else }}
                                     'server' => '{{ getenv "REDIS_HOST" }}',
 {{ end }}
@@ -36,7 +35,6 @@ return array (
                                     'timeout' => '0.5',
                                     'sentinel_master' => '{{ getenv "REDIS_SENTINEL_MASTER" }}',
                                     'sentinel_master_verify' => '1',
-                                    'load_from_slaves' => '2',
 {{ else }}
                                     'server' => '{{ getenv "REDIS_HOST" }}',
 {{ end }}


### PR DESCRIPTION
We were encountering pages that were blank due to corrupted layout cache.
We tracked it down to this setting - layout config was loading from the slaves, being edited, then saved to the master, leading to replication lag having an effect.