### PR TITLE
Update README for PHP 7.1 usage

### DIFF
--- a/php-nginx/Dockerfile
+++ b/php-nginx/Dockerfile
@@ -4,12 +4,18 @@ MAINTAINER Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>
 
 # Install PHP packages, including the Tideways extension
 ARG PHP_VERSION
-ENV PHP_VERSION=${PHP_VERSION:-7.0}
+ENV PHP_VERSION=${PHP_VERSION:-7.1}
 RUN echo 'deb http://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages debian main' > /etc/apt/sources.list.d/tideways.list \
  && curl -sS https://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages/EEB5E8F4.gpg | apt-key add - \
  && if [ "$PHP_VERSION" != "7.0" ]; then \
    echo 'deb http://ppa.launchpad.net/ondrej/php/ubuntu xenial main' > /etc/apt/sources.list.d/php-ppa.list; \
    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E5267A6C; \
+ fi \
+ && if [ "$PHP_VERSION" == "7.1" ]; then \
+    export LANG=C.UTF-8 \
+    && apt-get update \
+    && apt-get install -y software-properties-common python-software-properties \
+    && add-apt-repository ppa:ondrej/php; \
  fi \
  && apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \

--- a/php-nginx/Dockerfile
+++ b/php-nginx/Dockerfile
@@ -4,18 +4,12 @@ MAINTAINER Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>
 
 # Install PHP packages, including the Tideways extension
 ARG PHP_VERSION
-ENV PHP_VERSION=${PHP_VERSION:-7.1}
+ENV PHP_VERSION=${PHP_VERSION:-7.0}
 RUN echo 'deb http://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages debian main' > /etc/apt/sources.list.d/tideways.list \
  && curl -sS https://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages/EEB5E8F4.gpg | apt-key add - \
  && if [ "$PHP_VERSION" != "7.0" ]; then \
    echo 'deb http://ppa.launchpad.net/ondrej/php/ubuntu xenial main' > /etc/apt/sources.list.d/php-ppa.list; \
    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E5267A6C; \
- fi \
- && if [ "$PHP_VERSION" == "7.1" ]; then \
-    export LANG=C.UTF-8 \
-    && apt-get update \
-    && apt-get install -y software-properties-common python-software-properties \
-    && add-apt-repository ppa:ondrej/php; \
  fi \
  && apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \

--- a/php-nginx/README.md
+++ b/php-nginx/README.md
@@ -1,5 +1,21 @@
 # PHP NGINX
 
+For PHP 7.1 in a Dockerfile:
+```Dockerfile
+FROM quay.io/continuouspipe/php7.1-nginx:stable
+ARG GITHUB_TOKEN=
+
+COPY . /app
+RUN container build
+```
+or in a docker-compose.yml:
+```yml
+version: '3'
+services:
+  web:
+    image: quay.io/continuouspipe/php7.1-nginx:stable
+```
+
 For PHP 7.0 in a Dockerfile:
 ```Dockerfile
 FROM quay.io/continuouspipe/php7-nginx:stable
@@ -37,6 +53,10 @@ services:
 # For PHP 7.0
 docker-compose build php70_nginx
 docker-compose push php70_nginx
+
+# For PHP 7.0
+docker-compose build php71_nginx
+docker-compose push php71_nginx
 
 # For PHP 5.6
 docker-compose build php56_nginx

--- a/php-nginx/README.md
+++ b/php-nginx/README.md
@@ -50,13 +50,13 @@ services:
 
 ## How to build
 ```bash
+# For PHP 7.1
+docker-compose build php71_nginx
+docker-compose push php71_nginx
+
 # For PHP 7.0
 docker-compose build php70_nginx
 docker-compose push php70_nginx
-
-# For PHP 7.0
-docker-compose build php71_nginx
-docker-compose push php71_nginx
 
 # For PHP 5.6
 docker-compose build php56_nginx


### PR DESCRIPTION
Although the README has been updated to reflect the changes made, the shared images would still need to be created and uploaded. 

I am not 100% sure if this is the most optimal way of doing it but the built image is only 9MB larger than the PHP 7.0 version.