### PR TITLE
Fix solr6 infinite loop.

### DIFF
--- a/solr/6.2/docker-entrypoint-initdb.d/create-main-core.sh
+++ b/solr/6.2/docker-entrypoint-initdb.d/create-main-core.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 
+if [ -n "$IS_INNER_REQUEST" ]; then
+  return 0
+fi
 SOLR_CORE_NAME=${SOLR_CORE_NAME:-maincore}
-/opt/docker-solr/scripts/docker-entrypoint.sh solr-create -c "${SOLR_CORE_NAME}" -d /usr/local/share/solr/
+IS_INNER_REQUEST="true" /opt/docker-solr/scripts/docker-entrypoint.sh solr-create -c "${SOLR_CORE_NAME}" -d /usr/local/share/solr/


### PR DESCRIPTION
Solr's docker entry point brings in every file in /docker-entrypoint-initdb.d/*,
so calling the docker-entrypoint.sh script manually led to an infinite loop.