### PR TITLE
Stop passwords being logged during assets apply

### DIFF
--- a/php-apache/usr/local/share/assets/assets_functions.sh
+++ b/php-apache/usr/local/share/assets/assets_functions.sh
@@ -87,6 +87,7 @@ function assets_apply_database_mysql()
   fi
 
   wait_for_remote_ports "${ASSETS_DATABASE_WAIT_TIMEOUT}" "${DATABASE_HOST}:${DATABASE_PORT}"
+  set +x
 
   local DATABASES
   mapfile -t DATABASES < <(mysql "${DATABASE_ARGS[@]}" --execute="SHOW DATABASES" | tail --lines=+2)
@@ -155,6 +156,7 @@ function assets_apply_database_postgres()
   fi
 
   wait_for_remote_ports "${ASSETS_DATABASE_WAIT_TIMEOUT}" "${DATABASE_HOST}:${DATABASE_PORT}"
+  set +x
 
   local DATABASES
   mapfile -t DATABASES < <(PGPASSWORD="$PGPASSWORD" psql "${DATABASE_ARGS[@]}" -lqt | cut -d \| -f 1 | sed "s/ //g")

--- a/php-nginx/usr/local/share/assets/assets_functions.sh
+++ b/php-nginx/usr/local/share/assets/assets_functions.sh
@@ -87,6 +87,7 @@ function assets_apply_database_mysql()
   fi
 
   wait_for_remote_ports "${ASSETS_DATABASE_WAIT_TIMEOUT}" "${DATABASE_HOST}:${DATABASE_PORT}"
+  set +x
 
   local DATABASES
   mapfile -t DATABASES < <(mysql "${DATABASE_ARGS[@]}" --execute="SHOW DATABASES" | tail --lines=+2)
@@ -155,6 +156,7 @@ function assets_apply_database_postgres()
   fi
 
   wait_for_remote_ports "${ASSETS_DATABASE_WAIT_TIMEOUT}" "${DATABASE_HOST}:${DATABASE_PORT}"
+  set +x
 
   local DATABASES
   mapfile -t DATABASES < <(PGPASSWORD="$PGPASSWORD" psql "${DATABASE_ARGS[@]}" -lqt | cut -d \| -f 1 | sed "s/ //g")


### PR DESCRIPTION
wait_for_remote_ports re-enables the tracing, meaning the database commands that follow get logged.