### PR TITLE
Check files exist rather than executable when acceptable

### DIFF
--- a/magento1/usr/local/share/magento1/magento_functions.sh
+++ b/magento1/usr/local/share/magento1/magento_functions.sh
@@ -12,12 +12,12 @@ function do_magento_create_directories() {
 
 function do_magento_directory_permissions() {
   if [ "$IS_CHOWN_FORBIDDEN" != 'true' ]; then
-    [ ! -x "${MAGE_ROOT}/app/etc/local.xml" ] || chown -R "${CODE_OWNER}:${APP_GROUP}" "${MAGE_ROOT}/app/etc/local.xml"
+    [ ! -e "${MAGE_ROOT}/app/etc/local.xml" ] || chown -R "${CODE_OWNER}:${APP_GROUP}" "${MAGE_ROOT}/app/etc/local.xml"
     chown -R "${APP_USER}:${CODE_GROUP}" "${MAGE_ROOT}/media" "${MAGE_ROOT}/sitemaps" "${MAGE_ROOT}/staging" "${MAGE_ROOT}/var"
     chmod -R ug+rw,o-w "${MAGE_ROOT}/media" "${MAGE_ROOT}/sitemaps" "${MAGE_ROOT}/staging" "${MAGE_ROOT}/var"
     chmod -R a+r "${MAGE_ROOT}/media" "${MAGE_ROOT}/sitemaps" "${MAGE_ROOT}/staging"
   else
-    [ ! -x "${MAGE_ROOT}/app/etc/local.xml" ] || chmod a+r "${MAGE_ROOT}/app/etc/local.xml"
+    [ ! -e "${MAGE_ROOT}/app/etc/local.xml" ] || chmod a+r "${MAGE_ROOT}/app/etc/local.xml"
     chmod -R a+rw "${MAGE_ROOT}/media" "${MAGE_ROOT}/sitemaps" "${MAGE_ROOT}/staging" "${MAGE_ROOT}/var"
   fi
 }

--- a/ubuntu/16.04/usr/local/bin/container
+++ b/ubuntu/16.04/usr/local/bin/container
@@ -18,7 +18,7 @@ if [ "$#" -gt 0 ]; then
 fi
 
 source /usr/local/share/container/plan.sh
-if [ -x "$WORK_DIRECTORY/plan.sh" ]; then
+if [ -e "$WORK_DIRECTORY/plan.sh" ]; then
   # shellcheck source=/dev/null
   source "$WORK_DIRECTORY/plan.sh"
 fi


### PR DESCRIPTION
* Fixes magento image stopping php being able to read app/etc/local.xml
* Solves unnecessary need for plan.sh to be executable