### PR TITLE
Use return codes rather than true/false transposing in functions

### DIFF
--- a/magento2/usr/local/share/magento2/development/install.sh
+++ b/magento2/usr/local/share/magento2/development/install.sh
@@ -23,10 +23,7 @@ source "$DIR/replace_core_config_values.sh"
 bash "$DIR/../install_magento.sh";
 
 set -x
-set +e
-IS_HEM="$(is_hem_project)"
-set -e
-if [ "$IS_HEM" == 'true' ]; then
+if is_hem_project; then
   # Run HEM
   export HEM_RUN_ENV="${HEM_RUN_ENV:-local}"
   for asset_env in $ASSET_DOWNLOAD_ENVIRONMENTS; do

--- a/magento2/usr/local/share/magento2/development/install_assets.sh
+++ b/magento2/usr/local/share/magento2/development/install_assets.sh
@@ -10,9 +10,7 @@ set -x
 cd /app || exit 1
 
 if [ -f "$ASSET_ARCHIVE_PATH" ]; then
-  set +e
-  IS_CHOWN_FORBIDDEN="$(is_chown_forbidden)"
-  set -e
+  IS_CHOWN_FORBIDDEN="$(run_return_boolean is_chown_forbidden)"
 
   if [ "$IS_CHOWN_FORBIDDEN" != 'true' ]; then
     chown -R "${CODE_OWNER}:${CODE_GROUP}" pub/media

--- a/magento2/usr/local/share/magento2/install_magento.sh
+++ b/magento2/usr/local/share/magento2/install_magento.sh
@@ -16,9 +16,7 @@ fi
 
 cd /app || exit 1;
 
-set +e
-IS_CHOWN_FORBIDDEN="$(is_chown_forbidden)"
-set -e
+IS_CHOWN_FORBIDDEN="$(run_return_boolean is_chown_forbidden)"
 
 if [ ! -d "vendor" ] || [ ! -f "vendor/autoload.php" ]; then
   as_code_owner "composer config repositories.magento composer https://repo.magento.com/"

--- a/magento2/usr/local/share/magento2/install_magento_finalise.sh
+++ b/magento2/usr/local/share/magento2/install_magento_finalise.sh
@@ -15,7 +15,7 @@ fi
 cd /app || exit 1
 
 set +e
-IS_CHOWN_FORBIDDEN="$(is_chown_forbidden)"
+IS_CHOWN_FORBIDDEN="$(run_return_boolean is_chown_forbidden)"
 set -e
 
 if [ "$IS_CHOWN_FORBIDDEN" != 'true' ]; then
@@ -57,10 +57,7 @@ fi
 # (sad that we have to do that tho...)
 
 # Download the static assets
-set +e
-IS_HEM="$(is_hem_project)"
-set -e
-if [ "$IS_HEM" == 'true' ]; then
+if is_hem_project; then
   export HEM_RUN_ENV="${HEM_RUN_ENV:-local}"
   for asset_env in $ASSET_DOWNLOAD_ENVIRONMENTS; do
     as_build "hem --non-interactive --skip-host-checks assets download -e $asset_env"

--- a/php-apache/usr/local/share/php/common_functions.sh
+++ b/php-apache/usr/local/share/php/common_functions.sh
@@ -28,11 +28,11 @@ do_composer_postinstall_scripts() {
   as_code_owner 'composer run-script post-install-cmd'
 }
 
-has_composer_package() (
-  set -e
+has_composer_package() {
   if [ ! -f "composer.lock" ]; then
     return
   fi
 
   is_true "$(jq -c '(.packages + .["packages-dev"])[] | select(.name == "'"$1"'") | has("name")' composer.lock)"
-)
+  return "$?"
+}

--- a/php-nginx/usr/local/share/php/common_functions.sh
+++ b/php-nginx/usr/local/share/php/common_functions.sh
@@ -28,11 +28,11 @@ do_composer_postinstall_scripts() {
   as_code_owner 'composer run-script post-install-cmd'
 }
 
-has_composer_package() (
-  set -e
+has_composer_package() {
   if [ ! -f "composer.lock" ]; then
     return
   fi
 
   is_true "$(jq -c '(.packages + .["packages-dev"])[] | select(.name == "'"$1"'") | has("name")' composer.lock)"
-)
+  return "$?"
+}

--- a/symfony/usr/local/share/symfony/symfony_functions.sh
+++ b/symfony/usr/local/share/symfony/symfony_functions.sh
@@ -56,14 +56,17 @@ symfony_doctrine_mode() {
 
 uses_symfony_doctrine() {
   [ "$(symfony_doctrine_mode)" != "off" ]
+  return "$?"
 }
 
 uses_symfony_doctrine_mode_schema() {
   [ "$(symfony_doctrine_mode)" = "schema" ]
+  return "$?"
 }
 
 uses_symfony_doctrine_mode_migrations() {
   [ "$(symfony_doctrine_mode)" = "migrations" ]
+  return "$?"
 }
 
 do_database_rebuild() {

--- a/ubuntu/16.04/usr/local/share/bootstrap/common_functions.sh
+++ b/ubuntu/16.04/usr/local/share/bootstrap/common_functions.sh
@@ -80,6 +80,14 @@ convert_exit_code_to_string() {
   fi
 }
 
+run_return_boolean() {
+  if "$@"; then
+    echo 'true'
+  else
+    echo 'false'
+  fi
+}
+
 convert_to_boolean_string() {
   if [ "$1" == '1' ] || [ "$1" == "true" ]; then
     echo 'true';
@@ -117,30 +125,24 @@ is_false() {
 }
 
 is_hem_project() {
-  local RESULT=1
-  if [ -f /app/tools/hem/config.yaml ] || [ -f /app/tools/hobo/config.yaml ]; then
-    RESULT=0
-  fi
-  convert_exit_code_to_string "$RESULT"
+  [ -f /app/tools/hem/config.yaml ] || [ -f /app/tools/hobo/config.yaml ]
+  return "$?"
 }
 
 is_app_mountpoint() {
   grep -q -E "/app (nfs|vboxsf|fuse\\.osxfs)" /proc/mounts
-  local RESULT="$?"
-  convert_exit_code_to_string "$RESULT"
+  return "$?"
 }
 
 is_chown_forbidden() {
   # Determine if the app directory is an NFS mountpoint, which doesn't allow chowning.
   grep -q -E "/app (nfs|vboxsf)" /proc/mounts
-  local RESULT="$?"
-  convert_exit_code_to_string "$RESULT"
+  return "$?"
 }
 
 is_vboxsf_mountpoint() {
   grep -q "/app vboxsf" /proc/mounts
-  local RESULT="$?"
-  convert_exit_code_to_string "$RESULT"
+  return "$?"
 }
 
 alias_function() {

--- a/ubuntu/16.04/usr/local/share/env/50-bootstrap
+++ b/ubuntu/16.04/usr/local/share/env/50-bootstrap
@@ -8,16 +8,14 @@ START_CRON=${START_CRON:-false}
 START_CRON="$(convert_to_boolean_string "$START_CRON")"
 export START_CRON
 
-set +e
-IS_CHOWN_FORBIDDEN="$(is_chown_forbidden)"
+IS_CHOWN_FORBIDDEN="$(run_return_boolean is_chown_forbidden)"
 export IS_CHOWN_FORBIDDEN
 
-IS_VBOXSF_MOUNTPOINT="$(is_vboxsf_mountpoint)"
+IS_VBOXSF_MOUNTPOINT="$(run_return_boolean is_vboxsf_mountpoint)"
 export IS_VBOXSF_MOUNTPOINT
 
-IS_APP_MOUNTPOINT="$(is_app_mountpoint)"
+IS_APP_MOUNTPOINT="$(run_return_boolean is_app_mountpoint)"
 export IS_APP_MOUNTPOINT
-set -e
 
 DEVELOPMENT_MODE="$(convert_to_boolean_string_zero_is_true "${DEVELOPMENT_MODE:-${IS_APP_MOUNTPOINT}}")"
 export DEVELOPMENT_MODE


### PR DESCRIPTION
Additionally use `return "$?"` to solve possible cases where functions are called when set +e (or bash default)

```
if my_function
```

this will test the exit code of a function, which can either be a return status or an exit code, therefore the function doesn't need to change it to a true/false output

The boolean variables are going to still be used, as calling the functions instead will (with set -x) print out far more than a simple [ "$VAR" = "true" ]. Therefore this is best used when only called once per set of input arguments. `has_composer_package` for example needn't, as it's called with different input argments