### PR TITLE
Use subshells to avoid set calls needing to be reset

### DIFF
--- a/magento1/usr/local/share/magento1/magento_functions.sh
+++ b/magento1/usr/local/share/magento1/magento_functions.sh
@@ -45,7 +45,7 @@ function do_magento_frontend_build() {
   fi
 }
 
-function do_replace_core_config_values() {
+function do_replace_core_config_values() (
   set +x
   local SQL
   SQL="DELETE from core_config_data WHERE path LIKE 'web/%base_url';
@@ -61,8 +61,7 @@ function do_replace_core_config_values() {
   echo "$SQL"
   
   echo "$SQL" | mysql -h"$DATABASE_HOST" -u"$DATABASE_USER" -p"$DATABASE_PASSWORD" "$DATABASE_NAME"
-  set -x
-}
+)
 
 function do_magento_config_cache_enable() {
   as_code_owner "php /app/bin/n98-magerun.phar cache:enable config" "${MAGE_ROOT}"
@@ -85,7 +84,7 @@ function do_magento_cache_flush() {
   as_code_owner "php bin/n98-magerun.phar cache:flush"
 }
 
-function do_magento_create_admin_user() {
+function do_magento_create_admin_user() (
   if [ "$MAGENTO_CREATE_ADMIN_USER" != 'true' ]; then
     return 0
   fi
@@ -99,9 +98,8 @@ function do_magento_create_admin_user() {
     set +x
     echo "Creating admin user '$MAGENTO_ADMIN_USERNAME'"
     as_code_owner "php /app/bin/n98-magerun.phar admin:user:create '$MAGENTO_ADMIN_USERNAME' '$MAGENTO_ADMIN_EMAIL' '$MAGENTO_ADMIN_PASSWORD' '$MAGENTO_ADMIN_FORENAME' '$MAGENTO_ADMIN_SURNAME' Administrators" "${MAGE_ROOT}"
-    set -x
   fi
-}
+)
 
 function do_magento_templating() {
   :

--- a/magento2/usr/local/share/container/baseimage-30.sh
+++ b/magento2/usr/local/share/container/baseimage-30.sh
@@ -77,11 +77,11 @@ else
 fi
 
 
-do_magento() {
+do_magento() (
   set +x
   if [ "$#" -gt 0 ]; then
     as_app_user "./bin/magento $(printf "%q " "$@")"
   else
     as_app_user "./bin/magento"
   fi
-}
+)

--- a/magento2/usr/local/share/magento2/development/install_database.sh
+++ b/magento2/usr/local/share/magento2/development/install_database.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-do_magento_database_restore() {
+do_magento_database_restore() (
   set +x
   if [ -f "$DATABASE_ARCHIVE_PATH" ]; then
     local DATABASE_ARGS=(-h"$DATABASE_HOST")
@@ -34,7 +34,6 @@ do_magento_database_restore() {
       zcat "$DATABASE_ARCHIVE_PATH" | mysql "${DATABASE_ARGS[@]}" "$DATABASE_NAME" || exit 1
     fi
   fi
-  set -x
-}
+)
 
 do_magento_database_restore

--- a/magento2/usr/local/share/magento2/magento_functions.sh
+++ b/magento2/usr/local/share/magento2/magento_functions.sh
@@ -159,7 +159,7 @@ function do_magento_install_finalise_custom() {
   fi
 }
 
-function do_magento_drop_database() {
+function do_magento_drop_database() (
   set +x
 
   if [ "$FORCE_DATABASE_DROP" != 'true' ]; then
@@ -172,9 +172,9 @@ function do_magento_drop_database() {
   else
     mysql -h"$DATABASE_HOST" -uroot -e "DROP DATABASE IF EXISTS $DATABASE_NAME" || exit 1
   fi
-}
+)
 
-function check_magento_database_exists() {
+function check_magento_database_exists() (
   set +e
   local DATABASE_EXISTS
   if [ -n "$DATABASE_PASSWORD" ]; then
@@ -189,7 +189,7 @@ function check_magento_database_exists() {
   else
     echo "false";
   fi
-}
+)
 
 function do_magento_database_create() {
   echo 'Create Magento database'
@@ -200,14 +200,13 @@ function do_magento_database_create() {
   fi
 }
 
-function do_magento_database_install() {
+function do_magento_database_install() (
   set +x
   if [ -f "$DATABASE_ARCHIVE_PATH" ]; then
     do_magento_drop_database
 
     local DATABASE_EXISTS
     DATABASE_EXISTS="$(check_magento_database_exists)"
-    set -e
 
     if [ "$DATABASE_EXISTS" != "true" ]; then
       do_magento_database_create
@@ -221,16 +220,15 @@ function do_magento_database_install() {
     fi
   fi
   set -x
-}
+)
 
-function do_magento_installer_install() {
+function do_magento_installer_install() (
   set +x
   do_magento_wait_for_database
   do_magento_drop_database
 
   local DATABASE_EXISTS
   DATABASE_EXISTS="$(check_magento_database_exists)"
-  set -e
 
   if [ "$DATABASE_EXISTS" != "true" ]; then
     do_magento_database_create
@@ -253,9 +251,7 @@ function do_magento_installer_install() {
       --use-rewrites=1 \
       --session-save=db"
   fi
-
-  set -x
-}
+)
 
 function do_magento_wait_for_database() {
   if [ "$DATABASE_HOST" != 'localhost' ]; then
@@ -301,8 +297,7 @@ function do_magento_install_development_custom() {
   fi
 }
 
-function do_replace_core_config_values() {
-  set +x
+function do_replace_core_config_values() (
   local SQL
   SQL="DELETE from core_config_data WHERE path LIKE 'web/%base_url';
   DELETE from core_config_data WHERE path LIKE 'system/full_page_cache/varnish%';
@@ -321,9 +316,7 @@ function do_replace_core_config_values() {
   else
     echo "$SQL" | mysql -h"$DATABASE_HOST" -u"$DATABASE_USER" "$DATABASE_NAME"
   fi
-
-  set -x
-}
+)
 
 function do_magento_build_start_mysql() {
   apt-get update -qq -y
@@ -393,10 +386,9 @@ function do_magento_tail_logs() {
     /app/var/log/system.log
 }
 
-function do_magento_create_admin_user() {
+function do_magento_create_admin_user() (
   set +x
   if [ -z "${MAGENTO_ADMIN_USERNAME}" ] || [ -z "${MAGENTO_ADMIN_PASSWORD}" ]; then
-    set -x
     return 0
   fi
   local SQL="SELECT 1 FROM admin_user WHERE username='$MAGENTO_ADMIN_USERNAME'"
@@ -412,7 +404,6 @@ function do_magento_create_admin_user() {
   set -e
 
   if [ "$HAS_ADMIN_USER" != 0 ]; then
-    set +x
     as_code_owner "bin/magento admin:user:create \
       --admin-user='${MAGENTO_ADMIN_USERNAME}' \
       --admin-password='${MAGENTO_ADMIN_PASSWORD}' \
@@ -421,7 +412,7 @@ function do_magento_create_admin_user() {
       --admin-lastname='Admin'"
     set -x
   fi
-}
+)
 
 function do_magento2_build() {
 

--- a/php-apache/usr/local/share/assets/assets_functions.sh
+++ b/php-apache/usr/local/share/assets/assets_functions.sh
@@ -56,7 +56,7 @@ function assets_apply_database()
 }
 
 function assets_apply_database_mysql()
-{
+(
   set +x
   local DECOMPRESS
   local -r ASSET_FILE="$1"
@@ -87,7 +87,6 @@ function assets_apply_database_mysql()
   fi
 
   wait_for_remote_ports "${ASSETS_DATABASE_WAIT_TIMEOUT}" "${DATABASE_HOST}:${DATABASE_PORT}"
-  set +x
 
   local DATABASES
   mapfile -t DATABASES < <(mysql "${DATABASE_ARGS[@]}" --execute="SHOW DATABASES" | tail --lines=+2)
@@ -119,11 +118,10 @@ function assets_apply_database_mysql()
     echo "Importing ${ASSET_FILE} into ${APPLY_DATABASE_NAME} MySql database"
     "${DECOMPRESS[@]}" | mysql "${DATABASE_ARGS[@]}" "${APPLY_DATABASE_NAME}"
   fi
-  set -x
-}
+)
 
 function assets_apply_database_postgres()
-{
+(
   set +x
   local DECOMPRESS
   local -r ASSET_FILE="$1"
@@ -156,7 +154,6 @@ function assets_apply_database_postgres()
   fi
 
   wait_for_remote_ports "${ASSETS_DATABASE_WAIT_TIMEOUT}" "${DATABASE_HOST}:${DATABASE_PORT}"
-  set +x
 
   local DATABASES
   mapfile -t DATABASES < <(PGPASSWORD="$PGPASSWORD" psql "${DATABASE_ARGS[@]}" -lqt | cut -d \| -f 1 | sed "s/ //g")
@@ -189,8 +186,7 @@ function assets_apply_database_postgres()
     echo "Importing ${ASSET_FILE} into ${APPLY_DATABASE_NAME} MySql database"
     "${DECOMPRESS[@]}" | PGPASSWORD="$PGPASSWORD" psql "${DATABASE_ARGS[@]}" "${APPLY_DATABASE_NAME}"
   fi
-  set -x
-}
+)
 
 function do_assets_apply_database()
 {

--- a/php-nginx/usr/local/share/assets/assets_functions.sh
+++ b/php-nginx/usr/local/share/assets/assets_functions.sh
@@ -56,7 +56,7 @@ function assets_apply_database()
 }
 
 function assets_apply_database_mysql()
-{
+(
   set +x
   local DECOMPRESS
   local -r ASSET_FILE="$1"
@@ -87,7 +87,6 @@ function assets_apply_database_mysql()
   fi
 
   wait_for_remote_ports "${ASSETS_DATABASE_WAIT_TIMEOUT}" "${DATABASE_HOST}:${DATABASE_PORT}"
-  set +x
 
   local DATABASES
   mapfile -t DATABASES < <(mysql "${DATABASE_ARGS[@]}" --execute="SHOW DATABASES" | tail --lines=+2)
@@ -119,11 +118,10 @@ function assets_apply_database_mysql()
     echo "Importing ${ASSET_FILE} into ${APPLY_DATABASE_NAME} MySql database"
     "${DECOMPRESS[@]}" | mysql "${DATABASE_ARGS[@]}" "${APPLY_DATABASE_NAME}"
   fi
-  set -x
-}
+)
 
 function assets_apply_database_postgres()
-{
+(
   set +x
   local DECOMPRESS
   local -r ASSET_FILE="$1"
@@ -156,7 +154,6 @@ function assets_apply_database_postgres()
   fi
 
   wait_for_remote_ports "${ASSETS_DATABASE_WAIT_TIMEOUT}" "${DATABASE_HOST}:${DATABASE_PORT}"
-  set +x
 
   local DATABASES
   mapfile -t DATABASES < <(PGPASSWORD="$PGPASSWORD" psql "${DATABASE_ARGS[@]}" -lqt | cut -d \| -f 1 | sed "s/ //g")
@@ -189,8 +186,7 @@ function assets_apply_database_postgres()
     echo "Importing ${ASSET_FILE} into ${APPLY_DATABASE_NAME} MySql database"
     "${DECOMPRESS[@]}" | PGPASSWORD="$PGPASSWORD" psql "${DATABASE_ARGS[@]}" "${APPLY_DATABASE_NAME}"
   fi
-  set -x
-}
+)
 
 function do_assets_apply_database()
 {

--- a/spryker/usr/local/share/spryker/spryker_functions.sh
+++ b/spryker/usr/local/share/spryker/spryker_functions.sh
@@ -47,14 +47,13 @@ do_spryker_app_permissions() {
   fi
 }
 
-do_spryker_config_create() {
+do_spryker_config_create() (
   set +x
   echo "Creating Postgres Credentials file in /root/.pgpass"
   # create .pgpass in home directory for postgres client
   echo "$DATABASE_HOST:*:*:$DATABASE_USER:$DATABASE_PASSWORD" > /root/.pgpass
   chmod 0600 /root/.pgpass
-  set -x
-}
+)
 
 do_spryker_build() {
   do_spryker_directory_create

--- a/symfony/usr/local/share/symfony/symfony_functions.sh
+++ b/symfony/usr/local/share/symfony/symfony_functions.sh
@@ -144,11 +144,11 @@ do_symfony_build() {
   do_symfony_config_create
 }
 
-do_symfony_console() {
+do_symfony_console() (
   set +x
   if [ "$#" -gt 0 ]; then
     as_app_user "'$SYMFONY_CONSOLE' $(printf "%q " "$@")"
   else
     as_app_user "'$SYMFONY_CONSOLE'"
   fi
-}
+)

--- a/ubuntu/16.04/usr/local/share/bootstrap/common_functions.sh
+++ b/ubuntu/16.04/usr/local/share/bootstrap/common_functions.sh
@@ -38,7 +38,7 @@ get_user_home_directory() {
   getent passwd "$USER" | cut -d: -f 6
 }
 
-as_user() {
+as_user() (
   set +x
   local COMMAND="$1"
   local WORKING_DIR="$2"
@@ -55,22 +55,22 @@ as_user() {
   USER_HOME="$(get_user_home_directory "$USER")"
   set -x
   sudo -u "$USER" -E HOME="$USER_HOME" /bin/bash -c "cd '$WORKING_DIR'; $COMMAND"
-}
+)
 
-as_build() {
+as_build() (
   set +x
   as_user "$1" "$2" 'build'
-}
+)
 
-as_code_owner() {
+as_code_owner() (
   set +x
   as_user "$1" "$2" "$CODE_OWNER"
-}
+)
 
-as_app_user() {
+as_app_user() (
   set +x
   as_user "$1" "$2" "$APP_USER"
-}
+)
 
 convert_exit_code_to_string() {
   if [ "$1" -eq 0 ]; then
@@ -158,7 +158,7 @@ do_start() {
 }
 
 
-do_user_ssh_keys() {
+do_user_ssh_keys() (
   set +x
   local SSH_USER="$1"
   if [ -z "$SSH_USER" ]; then
@@ -191,8 +191,7 @@ do_user_ssh_keys() {
     unset SSH_PUBLIC_KEY
     unset SSH_KNOWN_HOSTS
   fi
-  set -x
-}
+)
 
 function do_enable_tracing() {
   export PS4='$(date "+%s.%N ($LINENO) + ")'
@@ -216,7 +215,7 @@ function do_clear_apt_caches() {
   rm -rf /var/lib/apt/lists/*
 }
 
-function wait_for_remote_ports() {
+function wait_for_remote_ports() (
   set +x
 
   local -r TIMEOUT=$1
@@ -236,9 +235,7 @@ function wait_for_remote_ports() {
     fi
     sleep "${INTERVAL}"
   done
-
-  set -x
-}
+)
 
 function test_remote_ports() {
   local SERVICE

--- a/ubuntu/16.04/usr/local/share/container/baseimage-10.sh
+++ b/ubuntu/16.04/usr/local/share/container/baseimage-10.sh
@@ -32,15 +32,13 @@ do_development_start() {
   :
 }
 
-do_build_user_ssh_keys() {
+do_build_user_ssh_keys() (
   set +x
   do_user_ssh_keys "build" "id_rsa" "$BUILD_USER_SSH_PRIVATE_KEY" "$BUILD_USER_SSH_PUBLIC_KEY" "$BUILD_USER_SSH_KNOWN_HOSTS"
-  set +x
   unset BUILD_USER_SSH_PRIVATE_KEY
   unset BUILD_USER_SSH_PUBLIC_KEY
   unset BUILD_USER_SSH_KNOWN_HOSTS
-  set -x
-}
+)
 
 do_setup() {
   :


### PR DESCRIPTION
Previously, if a function used set, it would need to set it back to original state, however that's not known. A subshell causes the parent shell to not get changed in the first place