### PR TITLE
Magento 2.2 Support

### DIFF
--- a/magento2/usr/local/share/container/baseimage-30.sh
+++ b/magento2/usr/local/share/container/baseimage-30.sh
@@ -24,6 +24,7 @@ if [ "$IMAGE_VERSION" -ge 2 ]; then
   alias_function do_composer do_magento2_composer_inner
   do_composer() {
     do_composer_config
+    do_composer_pre_install
     do_magento2_composer_inner
     do_composer_post_install
   }

--- a/magento2/usr/local/share/magento2/magento_functions.sh
+++ b/magento2/usr/local/share/magento2/magento_functions.sh
@@ -248,11 +248,10 @@ function do_magento_installer_install() {
 
     echo 'Install Magento 2 via the Installer'
     chmod +x bin/magento
-    as_code_owner "bin/magento setup:install --base-url='$PUBLIC_ADDRESS' \
+    local INSTALL_COMMAND="bin/magento setup:install --base-url='$PUBLIC_ADDRESS' \
       --db-host='$DATABASE_HOST' \
       --db-name='$DATABASE_NAME' \
       --db-user='$DATABASE_USER' \
-      --db-password='$DATABASE_PASSWORD' \
       --admin-firstname=Admin \
       --admin-lastname=Demo \
       --admin-user='${MAGENTO_ADMIN_USERNAME:-admin}' \
@@ -263,6 +262,10 @@ function do_magento_installer_install() {
       --timezone=Europe/London \
       --use-rewrites=1 \
       --session-save=db"
+    if [ -n "$DATABASE_PASSWORD" ]; then
+      INSTALL_COMMAND="${INSTALL_COMMAND} --db-password='${DATABASE_PASSWORD}'"
+    fi
+    as_code_owner "$INSTALL_COMMAND"
   fi
 
   set -x

--- a/magento2/usr/local/share/magento2/magento_functions.sh
+++ b/magento2/usr/local/share/magento2/magento_functions.sh
@@ -245,30 +245,34 @@ function do_magento_installer_install() {
 
   if [ "$DATABASE_EXISTS" != "true" ]; then
     do_magento_database_create
-
-    echo 'Install Magento 2 via the Installer'
-    chmod +x bin/magento
-    local INSTALL_COMMAND="bin/magento setup:install --base-url='$PUBLIC_ADDRESS' \
-      --db-host='$DATABASE_HOST' \
-      --db-name='$DATABASE_NAME' \
-      --db-user='$DATABASE_USER' \
-      --admin-firstname=Admin \
-      --admin-lastname=Demo \
-      --admin-user='${MAGENTO_ADMIN_USERNAME:-admin}' \
-      --admin-password='${MAGENTO_ADMIN_PASSWORD:-admin123}' \
-      --admin-email='${MAGENTO_ADMIN_EMAIL:-admin@example.com}' \
-      --language=en_GB \
-      --currency=GBP \
-      --timezone=Europe/London \
-      --use-rewrites=1 \
-      --session-save=db"
-    if [ -n "$DATABASE_PASSWORD" ]; then
-      INSTALL_COMMAND="${INSTALL_COMMAND} --db-password='${DATABASE_PASSWORD}'"
-    fi
-    as_code_owner "$INSTALL_COMMAND"
+    do_magento_clear_redis_cache
+    magento_installer_install
   fi
 
   set -x
+}
+
+function magento_installer_install() {
+  echo 'Install Magento 2 via the Installer'
+  chmod +x bin/magento
+  local INSTALL_COMMAND="bin/magento setup:install --base-url='$PUBLIC_ADDRESS' \
+    --db-host='$DATABASE_HOST' \
+    --db-name='$DATABASE_NAME' \
+    --db-user='$DATABASE_USER' \
+    --admin-firstname=Admin \
+    --admin-lastname=Demo \
+    --admin-user='${MAGENTO_ADMIN_USERNAME:-admin}' \
+    --admin-password='${MAGENTO_ADMIN_PASSWORD:-admin123}' \
+    --admin-email='${MAGENTO_ADMIN_EMAIL:-admin@example.com}' \
+    --language=en_GB \
+    --currency=GBP \
+    --timezone=Europe/London \
+    --use-rewrites=1 \
+    --session-save=db"
+  if [ -n "$DATABASE_PASSWORD" ]; then
+    INSTALL_COMMAND="${INSTALL_COMMAND} --db-password='${DATABASE_PASSWORD}'"
+  fi
+  as_code_owner "$INSTALL_COMMAND"
 }
 
 function do_magento_wait_for_database() {

--- a/magento2/usr/local/share/magento2/magento_functions.sh
+++ b/magento2/usr/local/share/magento2/magento_functions.sh
@@ -207,6 +207,9 @@ function do_magento_database_create() {
 
 function do_magento_database_install() {
   set +x
+  if [ "${DATABASE_HOST}" != "localhost" ]; then
+    wait_for_remote_ports "30" "${DATABASE_HOST}:${DATABASE_PORT}"
+  fi
   if [ -f "$DATABASE_ARCHIVE_PATH" ]; then
     do_magento_drop_database
 
@@ -230,6 +233,9 @@ function do_magento_database_install() {
 
 function do_magento_installer_install() {
   set +x
+  if [ "${DATABASE_HOST}" != "localhost" ]; then
+    wait_for_remote_ports "30" "${DATABASE_HOST}:${DATABASE_PORT}"
+  fi
   do_magento_wait_for_database
   do_magento_drop_database
 

--- a/magento2/usr/local/share/magento2/magento_functions.sh
+++ b/magento2/usr/local/share/magento2/magento_functions.sh
@@ -11,6 +11,11 @@ function do_composer_config() {
   fi
 }
 
+function do_composer_pre_install() {
+  mkdir -p /app/bin
+  chown -R "${CODE_OWNER}:${CODE_GROUP}" /app/bin
+}
+
 function do_composer_post_install() {
   if [ -f /app/bin/magento ]; then
     chmod +x /app/bin/magento
@@ -18,13 +23,13 @@ function do_composer_post_install() {
 }
 
 function do_magento_create_web_writable_directories() {
-  mkdir -p pub/media pub/static var/log var/report var/generation
+  mkdir -p pub/media pub/static var/log var/report var/generation generated
 
   if [ "$IS_CHOWN_FORBIDDEN" != 'true' ]; then
-    chown -R "${APP_USER}:${CODE_GROUP}" pub/media pub/static var
-    chmod -R ug+rw,o-w pub/media pub/static var
+    chown -R "${APP_USER}:${CODE_GROUP}" pub/media pub/static var generated
+    chmod -R ug+rw,o-w pub/media pub/static var generated
   else
-    chmod -R a+rw pub/media pub/static var
+    chmod -R a+rw pub/media pub/static var generated
   fi
 }
 
@@ -60,9 +65,9 @@ function do_magento_install_custom() {
 
 function do_magento_switch_web_writable_directories_to_code_owner() {
   if [ "$IS_CHOWN_FORBIDDEN" != 'true' ]; then
-    chown -R "${CODE_OWNER}":"${CODE_GROUP}" pub/media pub/static var
+    chown -R "${CODE_OWNER}":"${CODE_GROUP}" pub/media pub/static var generated
   else
-    chmod a+rw pub/media pub/static var
+    chmod a+rw pub/media pub/static var generated
   fi
 }
 
@@ -376,6 +381,7 @@ function do_magento_download_magerun2() {
 
 function do_magento2_templating() {
   mkdir -p /app/app/etc/
+  chown -R "${CODE_OWNER}:${CODE_GROUP}" /app/app/
 }
 
 function do_magento_catalog_image_resize() {

--- a/magento2/usr/local/share/magento2/magento_functions.sh
+++ b/magento2/usr/local/share/magento2/magento_functions.sh
@@ -395,6 +395,9 @@ function do_magento_download_magerun2() {
 function do_magento2_templating() {
   mkdir -p /app/app/etc/
   chown -R "${CODE_OWNER}:${CODE_GROUP}" /app/app/
+  if [ "${APP_USER_LOCAL}" == "true" ]; then
+    chown "${CODE_OWNER}:${CODE_GROUP}" /app/app/etc/env.php
+  fi
 }
 
 function do_magento_catalog_image_resize() {

--- a/magento2/usr/local/share/magento2/magento_functions.sh
+++ b/magento2/usr/local/share/magento2/magento_functions.sh
@@ -395,9 +395,6 @@ function do_magento_download_magerun2() {
 function do_magento2_templating() {
   mkdir -p /app/app/etc/
   chown -R "${CODE_OWNER}:${CODE_GROUP}" /app/app/
-  if [ "${APP_USER_LOCAL}" == "true" ]; then
-    chown "${CODE_OWNER}:${CODE_GROUP}" /app/app/etc/env.php
-  fi
 }
 
 function do_magento_catalog_image_resize() {


### PR DESCRIPTION
A few things have changed regarding validation of CLI parameters - database password cannot be empty, so setup:install fails during the docker build.

The `app` directory needs to be owned by the user running composer, to be able to create `bin/magento` later on (otherwise it silently exits).

Magento 2.2 adds a `generated` folder in the root of the codebase, which needs to be writeable by www-data like `var/generation/` used to be.

In gearing up for local development, we need to wait for the database to be available before running the installer or restoring a database.

Currently there is a setup bug with a few modules in 2.2rc2.1, and we have worked around this by running the installer twice, clearing redis cache in between!
This approach doesn't yet work in the build of the docker image (during `do_magento2_build`) but we are working on a solution for that.