### PR TITLE
Remove magento1 dev package removal

### DIFF
--- a/magento1/Dockerfile.tmpl
+++ b/magento1/Dockerfile.tmpl
@@ -21,7 +21,6 @@ RUN curl -sL https://deb.nodesource.com/setup_6.x > /tmp/install-node.sh \
  && npm rebuild node-sass \
  \
  # Clean the image \
- && apt-get remove -qq -y php{{PHP_VERSION}}-dev pkg-config libmagickwand-dev build-essential \
  && apt-get auto-remove -qq -y \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Even if the php-memcache extension was already installed here, none of these packages were a result of it. If they are installed, they are installed in the parent images and it's the parent image's responsibility to remove unneeded packages.

(Also this means we don't need to pass PHP_VERSION as an arg)