### PR TITLE
Add bzip2 to ubuntu image.

### DIFF
--- a/ubuntu/16.04/Dockerfile
+++ b/ubuntu/16.04/Dockerfile
@@ -14,6 +14,7 @@ RUN echo 'APT::Install-Recommends 0;' >> /etc/apt/apt.conf.d/01norecommends \
     acl \
     apt-transport-https \
     bash-completion \
+    bzip2 \
     ca-certificates \
     daemontools \
     cron \


### PR DESCRIPTION
* it's needed for the PHP assets tarball code
* it's used at times by PHP code with stream wrappers
* it'll generally compress files smaller than gzip
* it doesn't record a time compressed in it's header, so multiple compressions of the same sources result in matching files

(gzip is already in the ubuntu base image, so that's why it's not in the Dockerfile)