### PR TITLE
Add spryker_console command for access to spryker commands

### DIFF
--- a/spryker/usr/local/share/spryker/spryker_functions.sh
+++ b/spryker/usr/local/share/spryker/spryker_functions.sh
@@ -156,3 +156,12 @@ do_spryker_setup_search() {
 do_spryker_run_tests() {
   as_code_owner "vendor/bin/codecept run --skip Acceptance"
 }
+
+do_spryker_console() (
+  set +x
+  if [ "$#" -gt 0 ]; then
+    as_app_user "vendor/bin/console $(printf "%q " "$@")"
+  else
+    as_app_user "vendor/bin/console"
+  fi
+)


### PR DESCRIPTION
This allows a developer to run any Spryker console command on a CP container, for example if an importer needs to be run.