### PR TITLE
Hotfix: Fix spryker running console commands before having run composer.

### DIFF
--- a/spryker/usr/local/share/container/baseimage-45.sh
+++ b/spryker/usr/local/share/container/baseimage-45.sh
@@ -4,7 +4,8 @@ source /usr/local/share/spryker/spryker_functions.sh
 alias_function do_build_permissions do_spryker_build_permissions_inner
 do_build_permissions() {
   do_spryker_build_permissions_inner
-  do_spryker_build
+  do_spryker_directory_create
+  do_spryker_config_create
 }
 
 alias_function do_build do_spryker_nginx_build_inner

--- a/spryker/usr/local/share/container/baseimage-45.sh
+++ b/spryker/usr/local/share/container/baseimage-45.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
 source /usr/local/share/spryker/spryker_functions.sh
 
-alias_function do_build_permissions do_spryker_build_permissions_inner
-do_build_permissions() {
-  do_spryker_build_permissions_inner
-  do_spryker_directory_create
-  do_spryker_config_create
-}
-
 alias_function do_build do_spryker_nginx_build_inner
 do_build() {
   do_spryker_nginx_build_inner
@@ -30,6 +23,7 @@ do_start() {
 alias_function do_development_start do_spryker_development_start_inner
 do_development_start() {
   do_spryker_development_start_inner
+  do_spryker_build
   do_spryker_install
   do_spryker_app_permissions
 }


### PR DESCRIPTION
Potential fix for seeing vendor/bin/console used before composer install was called.