### PR TITLE
Ensure legacy assets cleanup is optional.

### DIFF
--- a/magento2/usr/local/share/magento2/magento_functions.sh
+++ b/magento2/usr/local/share/magento2/magento_functions.sh
@@ -303,6 +303,10 @@ function do_magento_assets_install() {
 }
 
 function do_magento_assets_cleanup() {
+  if [ -z "$DATABASE_ARCHIVE_PATH" ] && [ -z "$ASSET_ARCHIVE_PATH" ]; then
+    return
+  fi
+
   if [ -d /app/tools/assets/ ]; then
     find /app/tools/assets/ -type f ! -path "*${DATABASE_ARCHIVE_PATH}" -delete
   fi


### PR DESCRIPTION
This was interfering with the new do_assets_all asset installation. Only run this if the older variables are provided.