### PR TITLE
Call composer config upon Magento 2 startup.

### DIFF
--- a/magento2/usr/local/share/container/baseimage-30.sh
+++ b/magento2/usr/local/share/container/baseimage-30.sh
@@ -9,6 +9,12 @@ if [ "$IMAGE_VERSION" -ge 2 ]; then
     PRODUCTION_ENVIRONMENT="$BUILD_PRODUCTION_ENVIRONMENT" MAGENTO_MODE="$BUILD_MAGENTO_MODE" DEVELOPMENT_MODE="$BUILD_DEVELOPMENT_MODE" do_magento2_build
   }
 
+  alias_function do_start do_magento2_start_inner
+  do_start() {
+    do_magento2_start_inner
+    do_composer_config
+  }
+
   alias_function do_development_start do_magento2_development_start_inner
   do_development_start() {
     do_magento2_development_start_inner


### PR DESCRIPTION
In order to support development when composer install has happened in another container, set up ~build/.composer/auth.json on boot.