### PR TITLE
Set MAGE_MODE during the build as well as MAGENTO_MODE.

### DIFF
--- a/magento2/usr/local/share/container/baseimage-30.sh
+++ b/magento2/usr/local/share/container/baseimage-30.sh
@@ -7,7 +7,7 @@ if [ "$IMAGE_VERSION" -ge 2 ]; then
   do_build() {
     do_magento_build_start_mysql
     do_magento2_build_inner
-    PRODUCTION_ENVIRONMENT="$BUILD_PRODUCTION_ENVIRONMENT" MAGENTO_MODE="$BUILD_MAGENTO_MODE" DEVELOPMENT_MODE="$BUILD_DEVELOPMENT_MODE" do_magento2_build
+    PRODUCTION_ENVIRONMENT="$BUILD_PRODUCTION_ENVIRONMENT" MAGENTO_MODE="$BUILD_MAGENTO_MODE" MAGE_MODE="$BUILD_MAGENTO_MODE" DEVELOPMENT_MODE="$BUILD_DEVELOPMENT_MODE" do_magento2_build
   }
 
   alias_function do_start do_magento2_start_inner


### PR DESCRIPTION
Magento 2.2 is now using MAGE_MODE in preference to the one declared in env.php