### PR TITLE
DRY shell arg escaping and simplify console functions

### DIFF
--- a/magento2/usr/local/share/container/baseimage-30.sh
+++ b/magento2/usr/local/share/container/baseimage-30.sh
@@ -87,9 +87,5 @@ fi
 
 do_magento() (
   set +x
-  if [ "$#" -gt 0 ]; then
-    as_app_user "./bin/magento $(printf "%q " "$@")"
-  else
-    as_app_user "./bin/magento"
-  fi
+  as_app_user "$(escape_shell_args ./bin/magento "$@")"
 )

--- a/spryker/usr/local/share/spryker/spryker_functions.sh
+++ b/spryker/usr/local/share/spryker/spryker_functions.sh
@@ -159,9 +159,5 @@ do_spryker_run_tests() {
 
 do_spryker_console() (
   set +x
-  if [ "$#" -gt 0 ]; then
-    as_app_user "vendor/bin/console $(printf "%q " "$@")"
-  else
-    as_app_user "vendor/bin/console"
-  fi
+  as_app_user "$(escape_shell_args vendor/bin/console "$@")"
 )

--- a/symfony/usr/local/share/symfony/symfony_functions.sh
+++ b/symfony/usr/local/share/symfony/symfony_functions.sh
@@ -149,9 +149,5 @@ do_symfony_build() {
 
 do_symfony_console() (
   set +x
-  if [ "$#" -gt 0 ]; then
-    as_app_user "'$SYMFONY_CONSOLE' $(printf "%q " "$@")"
-  else
-    as_app_user "'$SYMFONY_CONSOLE'"
-  fi
+  as_app_user "$(escape_shell_args "$SYMFONY_CONSOLE" "$@")"
 )

--- a/ubuntu/16.04/usr/local/share/bootstrap/common_functions.sh
+++ b/ubuntu/16.04/usr/local/share/bootstrap/common_functions.sh
@@ -281,9 +281,5 @@ function do_list_functions() {
 }
 
 function do_shell() {
-  if [ "$#" -gt 0 ]; then
-    bash "$@"
-  else
-    bash
-  fi
+  bash "$@"
 }


### PR DESCRIPTION
You don't need to treat an empty array separately from another in the case of passing the arguments to a function/command