### PR TITLE
Add `do_bash` function

### DIFF
--- a/ubuntu/16.04/usr/local/share/container/baseimage-10.sh
+++ b/ubuntu/16.04/usr/local/share/container/baseimage-10.sh
@@ -47,3 +47,7 @@ do_setup() {
 do_migrate() {
   :
 }
+
+do_bash() {
+  /bin/bash
+}


### PR DESCRIPTION
For debugging purposes, this will allow us to get all the environment variables generated by our scripts.