### PR TITLE
Split composer run into parts

### DIFF
--- a/magento2/usr/local/share/container/baseimage-30.sh
+++ b/magento2/usr/local/share/container/baseimage-30.sh
@@ -28,9 +28,14 @@ if [ "$IMAGE_VERSION" -ge 2 ]; then
     do_magento2_templating_inner
   }
 
+  alias_function do_composer_config do_magento_composer_config_inner
+  do_composer_config() {
+    do_magento_composer_config_inner
+    do_magento_composer_config
+  }
+
   alias_function do_composer do_magento2_composer_inner
   do_composer() {
-    do_composer_config
     do_composer_pre_install
     do_magento2_composer_inner
     do_composer_post_install

--- a/magento2/usr/local/share/magento2/magento_functions.sh
+++ b/magento2/usr/local/share/magento2/magento_functions.sh
@@ -8,7 +8,7 @@ function detect_magento_version() {
   fi
 }
 
-function do_composer_config() {
+function do_magento_composer_config() {
   as_code_owner "composer global config repositories.magento composer https://repo.magento.com/"
 
   if [ -n "$MAGENTO_USERNAME" ] && [ -n "$MAGENTO_PASSWORD" ]; then

--- a/magento2/usr/local/share/magento2/magento_functions.sh
+++ b/magento2/usr/local/share/magento2/magento_functions.sh
@@ -8,8 +8,10 @@ function detect_magento_version() {
   fi
 }
 
-function do_magento_composer_config() {
+function do_magento_composer_config() (
   as_code_owner "composer global config repositories.magento composer https://repo.magento.com/"
+
+  set +x
 
   if [ -n "$MAGENTO_USERNAME" ] && [ -n "$MAGENTO_PASSWORD" ]; then
     as_code_owner "composer global config http-basic.repo.magento.com '$MAGENTO_USERNAME' '$MAGENTO_PASSWORD'"
@@ -17,7 +19,7 @@ function do_magento_composer_config() {
   if [ -n "$COMPOSER_CUSTOM_CONFIG_COMMAND" ]; then
     as_code_owner "$COMPOSER_CUSTOM_CONFIG_COMMAND"
   fi
-}
+)
 
 function do_composer_pre_install() {
   mkdir -p /app/bin

--- a/php/shared/usr/local/share/php/common_functions.sh
+++ b/php/shared/usr/local/share/php/common_functions.sh
@@ -8,11 +8,12 @@ do_build_permissions() {
   fi
 }
 
-do_composer_config() {
+do_composer_config() (
+  set +x
   if [ -n "$GITHUB_TOKEN" ]; then
     as_code_owner "composer global config github-oauth.github.com '$GITHUB_TOKEN'"
   fi
-}
+)
 
 run_composer() {
   as_code_owner "composer install ${COMPOSER_INSTALL_FLAGS}"

--- a/php/shared/usr/local/share/php/common_functions.sh
+++ b/php/shared/usr/local/share/php/common_functions.sh
@@ -8,20 +8,27 @@ do_build_permissions() {
   fi
 }
 
-run_composer() {
+do_composer_config() {
   if [ -n "$GITHUB_TOKEN" ]; then
     as_code_owner "composer global config github-oauth.github.com '$GITHUB_TOKEN'"
   fi
+}
 
+run_composer() {
   as_code_owner "composer install ${COMPOSER_INSTALL_FLAGS}"
-  rm -rf /home/build/.composer/cache/
-  as_code_owner "composer clear-cache"
 }
 
 do_composer() {
   if [ -f "${WORK_DIRECTORY}/composer.json" ]; then
+    do_composer_config
     run_composer
+    do_composer_clear_cache
   fi
+}
+
+do_composer_clear_cache() {
+  rm -rf /home/build/.composer/cache/
+  as_code_owner "composer clear-cache"
 }
 
 do_composer_postinstall_scripts() {


### PR DESCRIPTION
So we can ensure GITHUB_TOKEN is set in ~build/.composer/auth.json in the Magento2 image when called from `do_start` in https://github.com/continuouspipe/dockerfiles/blob/a1e76b97e70711cb1cbde4e4512d8e94768ffff3/magento2/usr/local/share/container/baseimage-30.sh#L16

It was observed that only the magento username/password were present in the composer auth file, so a manual run of `composer update <package>` in development was prompting for a token.