### PR TITLE
Add Elasticsearch 1.7.x for Akeneo

### DIFF
--- a/continuous-pipe.yml
+++ b/continuous-pipe.yml
@@ -197,7 +197,11 @@ tasks:
           image: quay.io/continuouspipe/drupal8-varnish4
           tag: ${FROM_TAG}
           reuse: false
-        elasticsearch:
+        elasticsearch17:
+          image: quay.io/continuouspipe/elasticsearch1.7
+          tag: ${FROM_TAG}
+          reuse: false
+        elasticsearch24:
           image: quay.io/continuouspipe/elasticsearch2.4
           tag: ${FROM_TAG}
           reuse: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,12 +67,23 @@ services:
     depends_on:
       - varnish
 
-  elasticsearch:
+  elasticsearch17:
     build:
       context: ./elasticsearch/
+      args:
+        FROM_TAG: '1.7'
+    image: quay.io/continuouspipe/elasticsearch1.7:latest
+    depends_on:
+      - external_elasticsearch17
+
+  elasticsearch24:
+    build:
+      context: ./elasticsearch/
+      args:
+        FROM_TAG: '2.4'
     image: quay.io/continuouspipe/elasticsearch2.4:latest
     depends_on:
-      - external_elasticsearch
+      - external_elasticsearch24
 
   ezplatform_php70_apache:
     build:
@@ -571,7 +582,10 @@ services:
   external_redis_highly_available:
     image: gcr.io/google_containers/redis:v1
 
-  external_elasticsearch:
+  external_elasticsearch17:
+    image: elasticsearch:1.7
+
+  external_elasticsearch24:
     image: elasticsearch:2.4
 
   external_postgres94:

--- a/elasticsearch/Dockerfile
+++ b/elasticsearch/Dockerfile
@@ -1,4 +1,5 @@
-FROM elasticsearch:2.4
+ARG FROM_TAG
+FROM elasticsearch:${FROM_TAG}
 
 MAINTAINER "Kieren Evans <kieren.evans+cp-dockerfiles@inviqa.com>"
 

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -1,22 +1,33 @@
-# Elasticsearch 2.4
+# Elasticsearch 1.7/2.4
 
-In a docker-compose.yml:
+In a docker-compose.yml for 2.4:
 ```yml
 version: '3'
 services:
   elasticsearch:
     image: quay.io/continuouspipe/elasticsearch2.4:stable
 ```
+or 1.7:
+```yml
+version: '3'
+services:
+  elasticsearch:
+    image: quay.io/continuouspipe/elasticsearch1.7:stable
+```
 
-In a Dockerfile:
+In a Dockerfile for 2.4:
 ```Dockerfile
 FROM quay.io/continuouspipe/elasticsearch2.4:stable
+```
+or 1.7:
+```Dockerfile
+FROM quay.io/continuouspipe/elasticsearch1.7:stable
 ```
 
 ## How to build
 ```bash
-docker-compose build --pull elasticsearch
-docker-compose push elasticsearch
+docker-compose build --pull elasticsearch24 elasticsearch17
+docker-compose push elasticsearch24 elasticsearch17
 ```
 
 ## About


### PR DESCRIPTION
2.x isn't supported for the official elasticsearch bundle for Akeneo