### PR TITLE
Fix latest tag not being used for master branch

### DIFF
--- a/continuous-pipe.yml
+++ b/continuous-pipe.yml
@@ -33,7 +33,7 @@ pipelines:
                 WEB_SERVER: nginx
     variables:
       - name: FROM_TAG
-        value: 'latest'
+        expression: '"latest"'
   - name: Feature Branches
     condition: '"Ready for Review" in pull_request.labels and not(code_reference.branch in ["master"])'
     tasks:


### PR DESCRIPTION
`expression` seem to win versus `value` now, causing `dev-master` tags to be used instead of `latest`
Please apply #427 first