### PR TITLE
Run the storage collectors before the search collectors

### DIFF
--- a/spryker/usr/local/share/spryker/spryker_functions.sh
+++ b/spryker/usr/local/share/spryker/spryker_functions.sh
@@ -131,8 +131,8 @@ do_spryker_migrate() {
 }
 
 do_spryker_run_collectors() {
-  as_app_user "vendor/bin/console collector:search:export"
   as_app_user "vendor/bin/console collector:storage:export"
+  as_app_user "vendor/bin/console collector:search:export"
 }
 
 do_spryker_propel_install() {


### PR DESCRIPTION
    * This should avoid am issue where the product data is missing
      in the storage, but is visible in the search results because
      the search collector has already run.