### PR TITLE
Spryker: A failed frontend build should still fail the build

### DIFF
--- a/spryker/usr/local/share/spryker/spryker_functions.sh
+++ b/spryker/usr/local/share/spryker/spryker_functions.sh
@@ -84,10 +84,8 @@ spryker_build_assets() {
 }
 
 do_spryker_build_assets() {
-  set +e
   ! spryker_service_yves || spryker_build_assets 'Yves'
   ! spryker_service_zed || spryker_build_assets 'Zed'
-  set -e
 }
 
 do_spryker_generate_files() {


### PR DESCRIPTION
Reverses the exit code ignoring change from https://github.com/continuouspipe/dockerfiles/commit/efac7db83edd722396c4838580470ca4bc00e18f