### PR TITLE
Support New Magento2 Redis Sentinel Patch

### DIFF
--- a/magento2/etc/confd/templates/magento/env.php.tmpl
+++ b/magento2/etc/confd/templates/magento/env.php.tmpl
@@ -63,6 +63,7 @@ return array (
             'redis' =>
             array (
 {{ if eq "true" (getenv "REDIS_USE_SENTINEL") }}
+                'host' => '{{ getenv "REDIS_SENTINEL_HOSTS" }}',
                 'sentinel_servers' => '{{ getenv "REDIS_SENTINEL_HOSTS" }}',
                 'sentinel_master' => '{{ getenv "REDIS_SENTINEL_MASTER" }}',
                 'sentinel_master_verify' => '1',


### PR DESCRIPTION
`sentinel_servers` was a patched in config value by a patch written by me to let php-redis-session-abstract be configured by env.php

Another patch in magento/magento2/pull/11222 uses "host" to match the syntax for the cache sections, so support both.