### PR TITLE
Ensure location based healthchecks do not redirect to HTTPS

### DIFF
--- a/nginx/etc/confd/templates/nginx/site_healthcheck.conf.tmpl
+++ b/nginx/etc/confd/templates/nginx/site_healthcheck.conf.tmpl
@@ -6,6 +6,10 @@ if ($http_user_agent ~ {{ getenv "AUTH_HTTP_HEALTHCHECK_USER_AGENT" }}) {
 }
 {{ end }}
 {{ if getenv "AUTH_HTTP_HEALTHCHECK_LOCATION" }}
+if ($request_uri = "{{ getenv "AUTH_HTTP_HEALTHCHECK_LOCATION" }}") {
+  set $do_https_redirect 0;
+}
+
 location = {{ getenv "AUTH_HTTP_HEALTHCHECK_LOCATION" }} {
   set $do_https_redirect 0;
   set $access_log_enabled 0;

--- a/php/nginx/etc/confd/templates/nginx/site_healthcheck.conf.tmpl
+++ b/php/nginx/etc/confd/templates/nginx/site_healthcheck.conf.tmpl
@@ -6,6 +6,10 @@ if ($http_user_agent ~ {{ getenv "AUTH_HTTP_HEALTHCHECK_USER_AGENT" }}) {
 }
 {{ end }}
 {{ if getenv "AUTH_HTTP_HEALTHCHECK_LOCATION" }}
+if ($request_uri = "{{ getenv "AUTH_HTTP_HEALTHCHECK_LOCATION" }}") {
+  set $do_https_redirect 0;
+}
+
 location = {{ getenv "AUTH_HTTP_HEALTHCHECK_LOCATION" }} {
   set $do_https_redirect 0;
   set $access_log_enabled 0;


### PR DESCRIPTION
For example, with use in varnish probes to avoid having to specify a custom `.request` of the `X-Forwarded-Proto: https` header.

The if statement for redirecting to HTTPS appears to be evaluated before the location block, so a 301 response is all that is given back to the probe, despite the `set $do_https_redirect 0;` inside the location block.