### PR TITLE
Add HTTP2 toggling for Nginx and option for HTTP2 over HTTP

### DIFF
--- a/php/nginx/README.md
+++ b/php/nginx/README.md
@@ -115,8 +115,8 @@ WEB_HTTPS | Whether to support HTTPS traffic on the WEB_HTTPS_PORT | true/false 
 WEB_HTTPS_PORT | The port to serve the HTTPS traffic from | 0-65535 | 443
 WEB_HTTPS_OFFLOADED | Whether the HTTPS traffic has been forwarded without SSL to the HTTPS port | true/false | false
 WEB_HTTPS_ONLY      | Whether to redirect all HTTP traffic to HTTPS | true/false | $WEB_HTTPS (deprecated: if $WEB_HTTPS=true then false)
-WEB_HTTP2 | Whether to enable HTTP2 over TLS on HTTPS port. If WEB_HTTPS_OFFLOADED enabled then this is ignored due to Nginx not supporting h2c | true/false | true
-WEB_HTTP2_ONLY_HTTP | Whether to enable HTTP2 over plaintext on HTTP port (or HTTPS if WEB_HTTPS_OFFLOADED enabled). Nginx doesn't support h2c for plain HTTP protocol so will not support HTTP 1.1/1.0 if enabled | true/false | false
+WEB_HTTP2_TLS | Whether to enable HTTP2 over TLS on HTTPS port. If WEB_HTTPS_OFFLOADED enabled then this is ignored as TLS is not used | true/false | true
+WEB_HTTP2_PLAINTEXT_NONBC | Whether to enable HTTP2 over plaintext on HTTP port (or HTTPS if WEB_HTTPS_OFFLOADED enabled). Nginx doesn't support h2c for plain HTTP protocol so will not support HTTP 1.1/1.0 if enabled | true/false | false
 WEB_REVERSE_PROXIED | Whether to interpret X-Forwarded-Proto as the $custom_scheme and $custom_https emulation. | true/false | true
 WEB_SSL_CIPHERS | The enabled SSL/TLS server ciphers | the format understood by the OpenSSL library | ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS
 WEB_SSL_FULLCHAIN | The location of the SSL certificate and intermediate chain file | absolute filename | /etc/ssl/certs/fullchain.pem

--- a/php/nginx/README.md
+++ b/php/nginx/README.md
@@ -115,6 +115,8 @@ WEB_HTTPS | Whether to support HTTPS traffic on the WEB_HTTPS_PORT | true/false 
 WEB_HTTPS_PORT | The port to serve the HTTPS traffic from | 0-65535 | 443
 WEB_HTTPS_OFFLOADED | Whether the HTTPS traffic has been forwarded without SSL to the HTTPS port | true/false | false
 WEB_HTTPS_ONLY      | Whether to redirect all HTTP traffic to HTTPS | true/false | $WEB_HTTPS (deprecated: if $WEB_HTTPS=true then false)
+WEB_HTTP2 | Whether to enable HTTP2 over TLS on HTTPS port. If WEB_HTTPS_OFFLOADED enabled then this is ignored due to Nginx not supporting h2c | true/false | true
+WEB_HTTP2_ONLY_HTTP | Whether to enable HTTP2 over plaintext on HTTP port (or HTTPS if WEB_HTTPS_OFFLOADED enabled). Nginx doesn't support h2c for plain HTTP protocol so will not support HTTP 1.1/1.0 if enabled | true/false | false
 WEB_REVERSE_PROXIED | Whether to interpret X-Forwarded-Proto as the $custom_scheme and $custom_https emulation. | true/false | true
 WEB_SSL_CIPHERS | The enabled SSL/TLS server ciphers | the format understood by the OpenSSL library | ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS
 WEB_SSL_FULLCHAIN | The location of the SSL certificate and intermediate chain file | absolute filename | /etc/ssl/certs/fullchain.pem

--- a/php/nginx/etc/confd/templates/nginx/site.conf.tmpl
+++ b/php/nginx/etc/confd/templates/nginx/site.conf.tmpl
@@ -1,7 +1,7 @@
 server {
     server_name {{ getenv "WEB_SERVER_NAME" }};
 {{ if ne "false" (getenv "WEB_HTTP") }}
-    listen {{ getenv "WEB_HTTP_PORT" }} {{ if eq "true" (getenv "WEB_DEFAULT_SERVER") }} default_server{{ end }}{{ if eq "true" (getenv "WEB_HTTP2_ONLY_HTTP") }} http2{{ end }};
+    listen {{ getenv "WEB_HTTP_PORT" }} {{ if eq "true" (getenv "WEB_DEFAULT_SERVER") }} default_server{{ end }}{{ if eq "true" (getenv "WEB_HTTP2_PLAINTEXT_NONBC") }} http2{{ end }};
 {{ if and (eq "true" (getenv "WEB_HTTPS_ONLY")) (ne "true" (getenv "WEB_REVERSE_PROXIED")) }}
 
     access_log off;
@@ -13,8 +13,8 @@ server {
 {{ end }}{{ end }}
 {{ if eq "true" (getenv "WEB_HTTPS") }}
 {{ if eq "true" (getenv "WEB_HTTPS_OFFLOADED") }}
-    listen {{ getenv "WEB_HTTPS_PORT" }}{{ if eq "true" (getenv "WEB_DEFAULT_SERVER") }} default_server{{ end }}{{ if eq "true" (getenv "WEB_HTTP2_ONLY_HTTP") }} http2{{ end }};{{ else }}
-    listen {{ getenv "WEB_HTTPS_PORT" }}{{ if eq "true" (getenv "WEB_DEFAULT_SERVER") }} default_server{{ end }} ssl{{ if eq "true" (getenv "WEB_HTTP2") }} http2{{ end }};
+    listen {{ getenv "WEB_HTTPS_PORT" }}{{ if eq "true" (getenv "WEB_DEFAULT_SERVER") }} default_server{{ end }}{{ if eq "true" (getenv "WEB_HTTP2_PLAINTEXT_NONBC") }} http2{{ end }};{{ else }}
+    listen {{ getenv "WEB_HTTPS_PORT" }}{{ if eq "true" (getenv "WEB_DEFAULT_SERVER") }} default_server{{ end }} ssl{{ if eq "true" (getenv "WEB_HTTP2_TLS") }} http2{{ end }};
     ssl_certificate {{ getenv "WEB_SSL_FULLCHAIN" }};
     ssl_certificate_key {{ getenv "WEB_SSL_PRIVKEY" }};{{ end }}{{ end }}
 

--- a/php/nginx/etc/confd/templates/nginx/site.conf.tmpl
+++ b/php/nginx/etc/confd/templates/nginx/site.conf.tmpl
@@ -1,7 +1,7 @@
 server {
     server_name {{ getenv "WEB_SERVER_NAME" }};
 {{ if ne "false" (getenv "WEB_HTTP") }}
-    listen {{ getenv "WEB_HTTP_PORT" }} {{ if eq "true" (getenv "WEB_DEFAULT_SERVER") }} default_server{{ end }};
+    listen {{ getenv "WEB_HTTP_PORT" }} {{ if eq "true" (getenv "WEB_DEFAULT_SERVER") }} default_server{{ end }}{{ if eq "true" (getenv "WEB_HTTP2_ONLY_HTTP") }} http2{{ end }};
 {{ if and (eq "true" (getenv "WEB_HTTPS_ONLY")) (ne "true" (getenv "WEB_REVERSE_PROXIED")) }}
 
     access_log off;
@@ -13,8 +13,8 @@ server {
 {{ end }}{{ end }}
 {{ if eq "true" (getenv "WEB_HTTPS") }}
 {{ if eq "true" (getenv "WEB_HTTPS_OFFLOADED") }}
-    listen {{ getenv "WEB_HTTPS_PORT" }}{{ if eq "true" (getenv "WEB_DEFAULT_SERVER") }} default_server{{ end }};{{ else }}
-    listen {{ getenv "WEB_HTTPS_PORT" }} {{ if eq "true" (getenv "WEB_DEFAULT_SERVER") }} default_server{{ end }} ssl http2;
+    listen {{ getenv "WEB_HTTPS_PORT" }}{{ if eq "true" (getenv "WEB_DEFAULT_SERVER") }} default_server{{ end }}{{ if eq "true" (getenv "WEB_HTTP2_ONLY_HTTP") }} http2{{ end }};{{ else }}
+    listen {{ getenv "WEB_HTTPS_PORT" }}{{ if eq "true" (getenv "WEB_DEFAULT_SERVER") }} default_server{{ end }} ssl{{ if eq "true" (getenv "WEB_HTTP2") }} http2{{ end }};
     ssl_certificate {{ getenv "WEB_SSL_FULLCHAIN" }};
     ssl_certificate_key {{ getenv "WEB_SSL_PRIVKEY" }};{{ end }}{{ end }}
 

--- a/php/nginx/usr/local/share/env/40-webserver
+++ b/php/nginx/usr/local/share/env/40-webserver
@@ -12,10 +12,10 @@ export START_NGINX
 START_PHP_FPM="$(convert_to_boolean_string "${START_PHP_FPM:-${START_MODE_WEB:-false}}")"
 export START_PHP_FPM
 
-WEB_HTTP2="$(convert_to_boolean_string "${WEB_HTTP2:-true}")"
-export WEB_HTTP2
-WEB_HTTP2_ONLY_HTTP="$(convert_to_boolean_string "${WEB_HTTP2_ONLY_HTTP:-false}")"
-export WEB_HTTP2_ONLY_HTTP
+WEB_HTTP2_TLS="$(convert_to_boolean_string "${WEB_HTTP2_TLS:-true}")"
+export WEB_HTTP2_TLS
+WEB_HTTP2_PLAINTEXT_NONBC="$(convert_to_boolean_string "${WEB_HTTP2_PLAINTEXT_NONBC:-false}")"
+export WEB_HTTP2_PLAINTEXT_NONBC
 
 export WEB_INCLUDES=${WEB_INCLUDES:-default-*}
 WEB_DEFAULT_SERVER="$(convert_to_boolean_string "${WEB_DEFAULT_SERVER:-true}")"

--- a/php/nginx/usr/local/share/env/40-webserver
+++ b/php/nginx/usr/local/share/env/40-webserver
@@ -12,6 +12,11 @@ export START_NGINX
 START_PHP_FPM="$(convert_to_boolean_string "${START_PHP_FPM:-${START_MODE_WEB:-false}}")"
 export START_PHP_FPM
 
+WEB_HTTP2="$(convert_to_boolean_string "${WEB_HTTP2:-true}")"
+export WEB_HTTP2
+WEB_HTTP2_ONLY_HTTP="$(convert_to_boolean_string "${WEB_HTTP2_ONLY_HTTP:-false}")"
+export WEB_HTTP2_ONLY_HTTP
+
 export WEB_INCLUDES=${WEB_INCLUDES:-default-*}
 WEB_DEFAULT_SERVER="$(convert_to_boolean_string "${WEB_DEFAULT_SERVER:-true}")"
 export WEB_DEFAULT_SERVER


### PR DESCRIPTION
Nginx already had HTTP2 enabled

Latter is disabled by default as:
* Nginx doesn't support H2C, so is unable to negotiate HTTP version, so instead uses a different env var toggle
* H2C isn't supported by browsers, so has limited use