### PR TITLE
Support customising tideways hostname and environment

### DIFF
--- a/tideways/Dockerfile
+++ b/tideways/Dockerfile
@@ -13,3 +13,4 @@ RUN echo 'deb http://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages debian m
  && rm -rf /var/lib/apt/lists/*
 
 COPY ./etc/ /etc/
+COPY ./usr/ /usr/

--- a/tideways/README.md
+++ b/tideways/README.md
@@ -32,3 +32,13 @@ daemon will forward the generated PHP profile logs to the Tideways API.
 
 As for all images based on the ubuntu base image, see
 [the base image README](../../ubuntu/16.04/README.md)
+
+
+#### Environment variables
+
+The following variables are supported
+
+Variable | Description | Expected values | Default
+--- | --- | --- | ----
+TIDEWAYS_HOSTNAME | The domain of the website to help filter in the Tideways UI | a domain | tideways-daemon
+TIDEWAYS_ENVIRONMENT | The environment of the website to help filter in the Tideways UI, if your plan allows for more than one environment | string | production

--- a/tideways/etc/confd/templates/supervisor/tideways_daemon.conf.tmpl
+++ b/tideways/etc/confd/templates/supervisor/tideways_daemon.conf.tmpl
@@ -1,5 +1,5 @@
 [program:tideways_daemon]
-command = /usr/bin/tideways-daemon --hostname=tideways-daemon --address=0.0.0.0:9135 --udp=0.0.0.0:9136
+command = /usr/bin/tideways-daemon --hostname="{{ getenv "TIDEWAYS_HOSTNAME" }}" --address=0.0.0.0:9135 --udp=0.0.0.0:9136 --env="{{ getenv "TIDEWAYS_ENVIRONMENT" }}"
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr

--- a/tideways/usr/local/share/env/40-stack
+++ b/tideways/usr/local/share/env/40-stack
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+export TIDEWAYS_HOSTNAME=${TIDEWAYS_HOSTNAME:-tideways-daemon}
+export TIDEWAYS_ENVIRONMENT=${TIDEWAYS_ENVIRONMENT:-production}


### PR DESCRIPTION
Stops multiple hosts/environments appearing as `tideways-daemon (production)` in the Tideways UI which makes it hard to track down the site you are interested in.