### PR TITLE
Add PHP 7.2 images in base and Symfony varients

### DIFF
--- a/continuous-pipe.yml
+++ b/continuous-pipe.yml
@@ -58,6 +58,13 @@ tasks:
           image: quay.io/continuouspipe/nginx
           tag: ${FROM_TAG}
           reuse: false
+        php72_apache:
+          image: quay.io/continuouspipe/php7.2-apache
+          tag: ${FROM_TAG}
+          reuse: false
+          environment:
+            PHP_VERSION: '7.2'
+            FROM_TAG: ${FROM_TAG}
         php71_apache:
           image: quay.io/continuouspipe/php7.1-apache
           tag: ${FROM_TAG}
@@ -78,6 +85,13 @@ tasks:
           reuse: false
           environment:
             PHP_VERSION: '5.6'
+            FROM_TAG: ${FROM_TAG}
+        php72_nginx:
+          image: quay.io/continuouspipe/php7.2-nginx
+          tag: ${FROM_TAG}
+          reuse: false
+          environment:
+            PHP_VERSION: '7.2'
             FROM_TAG: ${FROM_TAG}
         php71_nginx:
           image: quay.io/continuouspipe/php7.1-nginx
@@ -119,6 +133,14 @@ tasks:
   first_level_dependency_images:
     build:
       services:
+        symfony_php72_nginx:
+          image: quay.io/continuouspipe/symfony-php7.2-nginx
+          tag: ${FROM_TAG}
+          reuse: false
+          environment:
+            PHP_VERSION: '7.2'
+            WEB_SERVER: nginx
+            FROM_TAG: ${FROM_TAG}
         symfony_php71_nginx:
           image: quay.io/continuouspipe/symfony-php7.1-nginx
           tag: ${FROM_TAG}
@@ -126,6 +148,14 @@ tasks:
           environment:
             PHP_VERSION: '7.1'
             WEB_SERVER: nginx
+            FROM_TAG: ${FROM_TAG}
+        symfony_php72_apache:
+          image: quay.io/continuouspipe/symfony-php7.2-apache
+          tag: ${FROM_TAG}
+          reuse: false
+          environment:
+            PHP_VERSION: '7.2'
+            WEB_SERVER: apache
             FROM_TAG: ${FROM_TAG}
         symfony_php71_apache:
           image: quay.io/continuouspipe/symfony-php7.1-apache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -332,6 +332,16 @@ services:
     depends_on:
       - php71_apache
 
+  php72_apache:
+    build:
+      context: ./php/
+      dockerfile: Dockerfile-apache
+      args:
+        PHP_VERSION: '7.2'
+    image: quay.io/continuouspipe/php7.2-apache:latest
+    depends_on:
+      - ubuntu
+
   php71_apache:
     build:
       context: ./php/
@@ -359,6 +369,16 @@ services:
       args:
         PHP_VERSION: '5.6'
     image: quay.io/continuouspipe/php5.6-apache:latest
+    depends_on:
+      - ubuntu
+
+  php72_nginx:
+    build:
+      context: ./php/
+      dockerfile: Dockerfile-nginx
+      args:
+        PHP_VERSION: '7.2'
+    image: quay.io/continuouspipe/php7.2-nginx:latest
     depends_on:
       - ubuntu
 
@@ -484,6 +504,16 @@ services:
     depends_on:
       - php71_apache
 
+  symfony_php72_nginx:
+    build:
+      context: ./symfony/
+      args:
+        PHP_VERSION: '7.2'
+        WEB_SERVER: nginx
+    image: quay.io/continuouspipe/symfony-php7.2-nginx:latest
+    depends_on:
+      - php72_nginx
+
   symfony_php71_nginx:
     build:
       context: ./symfony/
@@ -513,6 +543,16 @@ services:
     image: quay.io/continuouspipe/symfony-php5.6-nginx:latest
     depends_on:
       - php56_nginx
+
+  symfony_php72_apache:
+    build:
+      context: ./symfony/
+      args:
+        PHP_VERSION: '7.2'
+        WEB_SERVER: apache
+    image: quay.io/continuouspipe/symfony-php7.2-apache:latest
+    depends_on:
+      - php72_apache
 
   symfony_php71_apache:
     build:

--- a/php/Dockerfile-apache
+++ b/php/Dockerfile-apache
@@ -30,7 +30,7 @@ RUN echo 'deb http://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages debian m
     "php$PHP_VERSION-gd" \
     "php$PHP_VERSION-intl" \
     "php$PHP_VERSION-mbstring" \
-    "php$PHP_VERSION-mcrypt" \
+    "$( dpkg --compare-versions "$PHP_VERSION" ge 7.2 || echo "php$PHP_VERSION-mcrypt" )" \
     "php$PHP_VERSION-opcache" \
     "php$PHP_VERSION-pgsql" \
     "php$PHP_VERSION-soap" \

--- a/php/Dockerfile-nginx
+++ b/php/Dockerfile-nginx
@@ -27,7 +27,7 @@ RUN echo 'deb http://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages debian m
     "php$PHP_VERSION-gd" \
     "php$PHP_VERSION-intl" \
     "php$PHP_VERSION-mbstring" \
-    "php$PHP_VERSION-mcrypt" \
+    "$( dpkg --compare-versions "$PHP_VERSION" ge 7.2 || echo "php$PHP_VERSION-mcrypt" )" \
     "php$PHP_VERSION-opcache" \
     "php$PHP_VERSION-pgsql" \
     "php$PHP_VERSION-soap" \

--- a/php/Dockerfile-nginx-phpsource
+++ b/php/Dockerfile-nginx-phpsource
@@ -29,7 +29,7 @@ RUN export PHP_VERSION=${PHP_FULL_VERSION%.[0-9]*} \
     libicu-dev \
     libjpeg-dev \
     libltdl-dev \
-    libmcrypt-dev \
+    "$( dpkg --compare-versions "$PHP_VERSION" ge 7.2 || echo "libmcrypt-dev" )" \
     libmemcached-dev \
     libmysqlclient-dev \
     libpng-dev \
@@ -75,7 +75,7 @@ RUN export PHP_VERSION=${PHP_FULL_VERSION%.[0-9]*} \
    --with-webp-dir=/usr \
    --enable-intl \
    --enable-mbstring \
-   --with-mcrypt \
+   "$( dpkg --compare-versions "$PHP_VERSION" ge 7.2 || echo "--with-mcrypt" )" \
    --with-mhash \
    --enable-mysqlnd \
    --with-mysql=mysqlnd \
@@ -117,7 +117,7 @@ RUN export PHP_VERSION=${PHP_FULL_VERSION%.[0-9]*} \
    --with-webp-dir=/usr \
    --enable-intl \
    --enable-mbstring \
-   --with-mcrypt \
+   "$( dpkg --compare-versions "$PHP_VERSION" ge 7.2 || echo "--with-mcrypt" )" \
    --with-mhash \
    --enable-mysqlnd \
    --with-mysql=mysqlnd \

--- a/php/apache/README.md
+++ b/php/apache/README.md
@@ -1,4 +1,35 @@
 # PHP Apache
+For PHP 7.2 in a Dockerfile:
+```Dockerfile
+FROM quay.io/continuouspipe/php7.2-apache:stable
+ARG GITHUB_TOKEN=
+
+COPY . /app
+RUN container build
+```
+or in a docker-compose.yml:
+```yml
+version: '3'
+services:
+  web:
+    image: quay.io/continuouspipe/php7.2-apache:stable
+```
+
+For PHP 7.1 in a Dockerfile:
+```Dockerfile
+FROM quay.io/continuouspipe/php7.1-apache:stable
+ARG GITHUB_TOKEN=
+
+COPY . /app
+RUN container build
+```
+or in a docker-compose.yml:
+```yml
+version: '3'
+services:
+  web:
+    image: quay.io/continuouspipe/php7.1-apache:stable
+```
 
 For PHP 7.0 in a Dockerfile:
 ```Dockerfile

--- a/php/nginx/README.md
+++ b/php/nginx/README.md
@@ -1,5 +1,21 @@
 # PHP NGINX
 
+For PHP 7.2 in a Dockerfile:
+```Dockerfile
+FROM quay.io/continuouspipe/php7.2-nginx:stable
+ARG GITHUB_TOKEN=
+
+COPY . /app
+RUN container build
+```
+or in a docker-compose.yml:
+```yml
+version: '3'
+services:
+  web:
+    image: quay.io/continuouspipe/php7.2-nginx:stable
+```
+
 For PHP 7.1 in a Dockerfile:
 ```Dockerfile
 FROM quay.io/continuouspipe/php7.1-nginx:stable

--- a/symfony/README.md
+++ b/symfony/README.md
@@ -67,6 +67,15 @@ var/cache/**
 
 In a Dockerfile:
 ```Dockerfile
+FROM quay.io/continuouspipe/symfony-php7.2-nginx:stable
+ARG GITHUB_TOKEN=
+ARG SYMFONY_ENV=prod
+
+COPY . /app/
+RUN container build
+```
+
+```Dockerfile
 FROM quay.io/continuouspipe/symfony-php7.1-nginx:stable
 ARG GITHUB_TOKEN=
 ARG SYMFONY_ENV=prod
@@ -96,6 +105,15 @@ RUN container build
 # Symfony with Apache
 
 In a Dockerfile:
+```Dockerfile
+FROM quay.io/continuouspipe/symfony-php7.2-apache:stable
+ARG GITHUB_TOKEN=
+ARG SYMFONY_ENV=prod
+
+COPY . /app/
+RUN container build
+```
+
 ```Dockerfile
 FROM quay.io/continuouspipe/symfony-php7.1-apache:stable
 ARG GITHUB_TOKEN=


### PR DESCRIPTION
PHP 7.2 removed mcrypt extension and moved to pecl.php.net.

Magento and Drupal aren't yet ready for it. Both additionally require mcrypt, however it'd be bad practice to include the pecl one. Instead a mcrypt polyfill could be used by the app.