### PR TITLE
Fix n98 download if the bin directory doesn't get created

### DIFF
--- a/magento1/usr/local/share/magento1/magento_functions.sh
+++ b/magento1/usr/local/share/magento1/magento_functions.sh
@@ -2,6 +2,7 @@
 
 function do_magento_n98_download() {
   if [ ! -f bin/n98-magerun.phar ]; then
+    as_code_owner "mkdir -p bin"
     as_code_owner "curl -o bin/n98-magerun.phar https://files.magerun.net/n98-magerun.phar"
   fi
 }


### PR DESCRIPTION
 (e.g. if composer is run with --no-dev).