### PR TITLE
Build in groups to avoid timeout

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,10 +8,15 @@ else
     DIR="$(dirname "$0")" ;
 fi ;
 
-for file in "${DIR}"/*/build.sh; do
-  # shellcheck source=/dev/null
-  bash "${file}"
-done
+
+shopt -s nullglob
+set -- "${DIR}"/*/build.sh
+if [ "$#" -gt 0 ]; then
+  for file in "$@"; do
+    # shellcheck source=/dev/null
+    source "${file}"
+  done
+fi
 
 echo "Pulling any external images:"; echo
 (cd "$DIR" && grep 'external_.*:' "$DIR/docker-compose.yml" | cut -d":" -f1 | xargs docker-compose pull)

--- a/continuous-pipe.yml
+++ b/continuous-pipe.yml
@@ -10,8 +10,10 @@ pipelines:
       - third_level_dependency_images
       - second_level_dependency_images
       - first_level_dependency_images
-      - no_dependency_images_a_m
-      - no_dependency_images_n_z
+      - no_dependency_images_a_g
+      - no_dependency_images_h_m
+      - no_dependency_images_n_r
+      - no_dependency_images_s_z
       - first_level_dependency_eol_images
       - no_dependency_eol_images
     variables:
@@ -31,8 +33,10 @@ pipelines:
       - third_level_dependency_images
       - second_level_dependency_images
       - first_level_dependency_images
-      - no_dependency_images_a_m
-      - no_dependency_images_n_z
+      - no_dependency_images_a_g
+      - no_dependency_images_h_m
+      - no_dependency_images_n_r
+      - no_dependency_images_s_z
 
 tasks:
   ##################################################
@@ -177,9 +181,9 @@ tasks:
             FROM_TAG: ${FROM_TAG}
 
   ##############################
-  # No dependency images (A-M) #
+  # No dependency images (A-G) #
   ##############################
-  no_dependency_images_a_m:
+  no_dependency_images_a_g:
     build:
       environment:
         FROM_TAG: ${FROM_TAG}
@@ -262,6 +266,15 @@ tasks:
           environment:
             PHP_VERSION: '7.1'
             FROM_TAG: ${FROM_TAG}
+
+  ##############################
+  # No dependency images (H-M) #
+  ##############################
+  no_dependency_images_h_m:
+    build:
+      environment:
+        FROM_TAG: ${FROM_TAG}
+      services:
         hem:
           image: quay.io/continuouspipe/hem1
           tag: ${FROM_TAG}
@@ -348,9 +361,9 @@ tasks:
             FROM_TAG: '5.5'
 
   ##############################
-  # No dependency images (N-Z) #
+  # No dependency images (N-R) #
   ##############################
-  no_dependency_images_n_z:
+  no_dependency_images_n_r:
     build:
       environment:
         FROM_TAG: ${FROM_TAG}
@@ -443,6 +456,15 @@ tasks:
           image: quay.io/continuouspipe/redis3-highly-available
           tag: ${FROM_TAG}
           reuse: false
+
+  ##############################
+  # No dependency images (S-Z) #
+  ##############################
+  no_dependency_images_s_z:
+    build:
+      environment:
+        FROM_TAG: ${FROM_TAG}
+      services:
         scala_sbt:
           image: quay.io/continuouspipe/scala-base
           tag: ${FROM_TAG}

--- a/continuous-pipe.yml
+++ b/continuous-pipe.yml
@@ -10,7 +10,8 @@ pipelines:
       - third_level_dependency_images
       - second_level_dependency_images
       - first_level_dependency_images
-      - no_dependency_images
+      - no_dependency_images_a_m
+      - no_dependency_images_n_z
       - first_level_dependency_eol_images
       - no_dependency_eol_images
     variables:
@@ -30,7 +31,8 @@ pipelines:
       - third_level_dependency_images
       - second_level_dependency_images
       - first_level_dependency_images
-      - no_dependency_images
+      - no_dependency_images_a_m
+      - no_dependency_images_n_z
 
 tasks:
   ##################################################
@@ -174,10 +176,10 @@ tasks:
             WEB_SERVER: apache
             FROM_TAG: ${FROM_TAG}
 
-  ###########################
-  # No dependency images    #
-  ###########################
-  no_dependency_images:
+  ##############################
+  # No dependency images (A-M) #
+  ##############################
+  no_dependency_images_a_m:
     build:
       environment:
         FROM_TAG: ${FROM_TAG}
@@ -344,6 +346,15 @@ tasks:
           reuse: false
           environment:
             FROM_TAG: '5.5'
+
+  ##############################
+  # No dependency images (N-Z) #
+  ##############################
+  no_dependency_images_n_z:
+    build:
+      environment:
+        FROM_TAG: ${FROM_TAG}
+      services:
         nginx_ingress_controller:
           image: quay.io/continuouspipe/nginx-ingress-controller
           tag: ${FROM_TAG}
@@ -420,6 +431,10 @@ tasks:
           reuse: false
           environment:
             FROM_TAG: '9.6'
+        rabbitmq36_management:
+          image: quay.io/continuouspipe/rabbitmq36-management
+          tag: ${FROM_TAG}
+          reuse: false
         redis:
           image: quay.io/continuouspipe/redis3
           tag: ${FROM_TAG}
@@ -478,10 +493,6 @@ tasks:
             FROM_TAG: ${FROM_TAG}
         tideways:
           image: quay.io/continuouspipe/tideways
-          tag: ${FROM_TAG}
-          reuse: false
-        rabbitmq36_management:
-          image: quay.io/continuouspipe/rabbitmq36-management
           tag: ${FROM_TAG}
           reuse: false
 


### PR DESCRIPTION
History of builds is not great -  some images haven't been built in ages due to timeouts.

I have a hunch it's per a TideCommand timeout so splitting into two groups should hopefully help us get past it.

Tagging as "Ready for Review" to see how far the build gets.