### PR TITLE
remove duplicate pgsql php extension from nginx/apache

### DIFF
--- a/php/Dockerfile-apache
+++ b/php/Dockerfile-apache
@@ -32,7 +32,6 @@ RUN echo 'deb http://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages debian m
     "php$PHP_VERSION-mbstring" \
     "$( dpkg --compare-versions "$PHP_VERSION" ge 7.2 || echo "php$PHP_VERSION-mcrypt" )" \
     "php$PHP_VERSION-opcache" \
-    "php$PHP_VERSION-pgsql" \
     "php$PHP_VERSION-soap" \
     "php$PHP_VERSION-xsl" \
     "php$PHP_VERSION-zip" \

--- a/php/Dockerfile-nginx
+++ b/php/Dockerfile-nginx
@@ -29,7 +29,6 @@ RUN echo 'deb http://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages debian m
     "php$PHP_VERSION-mbstring" \
     "$( dpkg --compare-versions "$PHP_VERSION" ge 7.2 || echo "php$PHP_VERSION-mcrypt" )" \
     "php$PHP_VERSION-opcache" \
-    "php$PHP_VERSION-pgsql" \
     "php$PHP_VERSION-soap" \
     "php$PHP_VERSION-xsl" \
     "php$PHP_VERSION-zip" \


### PR DESCRIPTION
It's not a big deal, I don't think it will reduce the build time... but still :)

ℹ️  It seems to have been introduced in https://github.com/continuouspipe/dockerfiles/pull/331