### PR TITLE
Make app mountpoint detection more generic. Picks up ext4, ext3 mounts, etc.

### DIFF
--- a/ubuntu/16.04/usr/local/share/bootstrap/common_functions.sh
+++ b/ubuntu/16.04/usr/local/share/bootstrap/common_functions.sh
@@ -137,7 +137,7 @@ is_hem_project() {
 }
 
 is_app_mountpoint() {
-  grep -q -E "/app (nfs|vboxsf|fuse\\.osxfs)" /proc/mounts
+  findmnt "$WORK_DIRECTORY" > /dev/null
   return "$?"
 }
 


### PR DESCRIPTION
Similar to #163 by @dcole-inviqa but doesn't go quite as far.

Specifically this fixes where https://github.com/continuouspipe/dockerfiles/blob/master/spryker/usr/local/share/spryker/spryker_functions.sh#L64 isn't firing when set up for local development - /app is a mountpoint, either ext4 for docker-sync/linux or osxfs for delegated volumes.