### PR TITLE
Fix elasticsearch 5.6 build

### DIFF
--- a/elasticsearch/Dockerfile-elastic
+++ b/elasticsearch/Dockerfile-elastic
@@ -2,5 +2,5 @@ ARG FROM_TAG
 FROM docker.elastic.co/elasticsearch/elasticsearch:${FROM_TAG}
 
 USER root
-RUN yum update && yum upgrade -y && yum clean all
+RUN yum makecache fast && yum upgrade -y && yum clean all
 USER elasticsearch


### PR DESCRIPTION
yum update is like yum upgrade, rather than downloading metadata like apt.