### PR TITLE
Add integration tests and a simple one for PHP to start us off 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ sudo: required
 services:
   - docker
 
+addons:
+  apt:
+    packages:
+      - parallel
+
 env:
   DOCKER_COMPOSE_VERSION: 1.23.0-rc3
 

--- a/README.md
+++ b/README.md
@@ -65,11 +65,13 @@ Other:
 
 We try to follow best practises when creating shell scripts and Dockerfiles.
 
-To run the best practise checkers, install [shellcheck](https://github.com/koalaman/shellcheck) and
-[hadolint](https://github.com/lukasmartinelli/hadolint) then run:
+To help aim for this, we use the following tools:
+* [shellcheck](https://github.com/koalaman/shellcheck) - checks syntax and best practises for shell scripts
+* [hadolint](https://github.com/lukasmartinelli/hadolint) - checks syntax and best practises for Dockerfiles
+* [BATS](https://github.com/sstephenson/bats) - unit tests for bash scripts
+* Integration tests using docker-compose and shell scripts
 
+To run all of these tools, you can use the helper script in the project root:
 ```bash
 bash test.sh
 ```
-
-This run shellcheck for every script found and hadolint for every Dockerfile.

--- a/docker-compose.eol.yml
+++ b/docker-compose.eol.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 services:
   magento1_php55_nginx:
     build:

--- a/docker-compose.stable.yml
+++ b/docker-compose.stable.yml
@@ -1,5 +1,5 @@
 ---
-version: '2'
+version: '3'
 services:
   couchdb16_stable:
     image: quay.io/continuouspipe/couchdb1.6:stable

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 services:
   tests:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 
 services:
   couchdb16:

--- a/php/tests/integration/Dockerfile
+++ b/php/tests/integration/Dockerfile
@@ -1,0 +1,6 @@
+ARG IMAGE_NAME=
+FROM quay.io/continuouspipe/$IMAGE_NAME:latest
+
+COPY . /app
+
+RUN container build

--- a/php/tests/integration/docker-compose.yml
+++ b/php/tests/integration/docker-compose.yml
@@ -1,0 +1,73 @@
+version: '3'
+services:
+  web_7_2_nginx:
+    build:
+      context: ./php/tests/integration/
+      args:
+        IMAGE_NAME: 'php7.2-nginx'
+    depends_on:
+      - php72_nginx
+  web_7_2_apache:
+    build:
+      context: ./php/tests/integration/
+      args:
+        IMAGE_NAME: 'php7.2-apache'
+    depends_on:
+      - php72_apache
+  web_7_1_nginx:
+    build:
+      context: ./php/tests/integration/
+      args:
+        IMAGE_NAME: 'php7.1-nginx'
+    depends_on:
+      - php71_nginx
+  web_7_1_apache:
+    build:
+      context: ./php/tests/integration/
+      args:
+        IMAGE_NAME: 'php7.1-apache'
+    depends_on:
+      - php71_apache
+  web_7_0_nginx:
+    build:
+      context: ./php/tests/integration/
+      args:
+        IMAGE_NAME: 'php7-nginx'
+    depends_on:
+      - php70_nginx
+  web_7_0_apache:
+    build:
+      context: ./php/tests/integration/
+      args:
+        IMAGE_NAME: 'php7-apache'
+    depends_on:
+      - php70_apache
+  web_5_6_nginx:
+    build:
+      context: ./php/tests/integration/
+      args:
+        IMAGE_NAME: 'php5.6-nginx'
+    depends_on:
+      - php56_nginx
+  web_5_6_apache:
+    build:
+      context: ./php/tests/integration/
+      args:
+        IMAGE_NAME: 'php5.6-apache'
+    depends_on:
+      - php56_apache
+
+  integration_tests:
+    image: quay.io/continuouspipe/php7.2-nginx:latest
+    depends_on:
+      - web_7_2_nginx
+      - web_7_2_apache
+      - web_7_1_nginx
+      - web_7_1_apache
+      - web_7_0_nginx
+      - web_7_0_apache
+      - web_5_6_nginx
+      - web_5_6_apache
+    command: "container run_tests"
+    volumes:
+      - ./php/tests/integration/tests/:/app/

--- a/php/tests/integration/tests/plan.sh
+++ b/php/tests/integration/tests/plan.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+do_run_tests()
+{
+  set -o pipefail
+  local SERVICE_NAME
+  for version in 7.2 7.1 5.6; do
+    SERVICE_NAME="web_${version/./_}"
+    wait_for_remote_ports 60 "$SERVICE_NAME:443"
+    curl --insecure --fail "https://$SERVICE_NAME/" | grep PHP_VERSION | grep -q "$version"
+  done
+
+  # shellcheck disable=SC2043
+  for version in 7; do
+    SERVICE_NAME="web_${version}_0"
+    wait_for_remote_ports 60 "$SERVICE_NAME:443"
+    curl --insecure --fail "https://$SERVICE_NAME/" | grep PHP_VERSION | grep -q "${version}\.0"
+  done
+}

--- a/php/tests/integration/tests/plan.sh
+++ b/php/tests/integration/tests/plan.sh
@@ -4,16 +4,18 @@ do_run_tests()
 {
   set -o pipefail
   local SERVICE_NAME
-  for version in 7.2 7.1 5.6; do
-    SERVICE_NAME="web_${version/./_}"
-    wait_for_remote_ports 60 "$SERVICE_NAME:443"
-    curl --insecure --fail "https://$SERVICE_NAME/" | grep PHP_VERSION | grep -q "$version"
-  done
+  for server in nginx apache; do
+    for version in 7.2 7.1 5.6; do
+      SERVICE_NAME="web_${version/./_}_${server}"
+      wait_for_remote_ports 60 "$SERVICE_NAME:443"
+      curl --insecure --fail "https://$SERVICE_NAME/" | grep PHP_VERSION | grep -q "$version"
+    done
 
-  # shellcheck disable=SC2043
-  for version in 7; do
-    SERVICE_NAME="web_${version}_0"
-    wait_for_remote_ports 60 "$SERVICE_NAME:443"
-    curl --insecure --fail "https://$SERVICE_NAME/" | grep PHP_VERSION | grep -q "${version}\.0"
+    # shellcheck disable=SC2043
+    for version in 7; do
+      SERVICE_NAME="web_${version}_0_${server}"
+      wait_for_remote_ports 60 "$SERVICE_NAME:443"
+      curl --insecure --fail "https://$SERVICE_NAME/" | grep PHP_VERSION | grep -q "${version}\.0"
+    done
   done
 }

--- a/php/tests/integration/web/index.php
+++ b/php/tests/integration/web/index.php
@@ -1,0 +1,2 @@
+<?php
+phpinfo();

--- a/test.sh
+++ b/test.sh
@@ -31,6 +31,6 @@ docker-compose -f docker-compose.yml -f docker-compose.test.yml run --rm tests
 # Run integration tests
 find "$DIR" -type f -path "*/tests/integration/docker-compose.yml" | while read -r integration_docker_compose; do
   echo "Running integration tests for '$integration_docker_compose':"
-  docker-compose -f "$DIR/docker-compose.yml" -f "$integration_docker_compose" up  --exit-code-from integration_tests integration_tests;
+  docker-compose -f "$DIR/docker-compose.yml" -f "$integration_docker_compose" up --build --exit-code-from integration_tests integration_tests;
   docker-compose -f "$DIR/docker-compose.yml" -f "$integration_docker_compose" down -v --rmi local
 done

--- a/test.sh
+++ b/test.sh
@@ -25,4 +25,12 @@ find "$DIR" -type f -name "Dockerfile*" ! -name "*.tmpl" | while read -r dockerf
   echo
 done
 
+# Run unit tests
 docker-compose -f docker-compose.yml -f docker-compose.test.yml run --rm tests
+
+# Run integration tests
+find "$DIR" -type f -path "*/tests/integration/docker-compose.yml" | while read -r integration_docker_compose; do
+  echo "Running integration tests for '$integration_docker_compose':"
+  docker-compose -f "$DIR/docker-compose.yml" -f "$integration_docker_compose" up  --exit-code-from integration_tests integration_tests;
+  docker-compose -f "$DIR/docker-compose.yml" -f "$integration_docker_compose" down -v --rmi local
+done

--- a/test.sh
+++ b/test.sh
@@ -3,9 +3,9 @@
 set -e
 
 if [ -L "$0" ] ; then
-    DIR="$(dirname "$(readlink -f "$0")")" ;
+    DIR="$(dirname "$(readlink -f "$0")")"
 else
-    DIR="$(dirname "$0")" ;
+    DIR="$(dirname "$0")"
 fi
 
 docker pull koalaman/shellcheck:v0.4.6
@@ -14,26 +14,22 @@ docker pull lukasmartinelli/hadolint
 run_shellcheck()
 {
   local script="$1"
-  echo "Linting '$script':";
-  docker run --rm -i koalaman/shellcheck:v0.4.6 --exclude SC1091 - < "$script";
-  echo
+  docker run --rm -i koalaman/shellcheck:v0.4.6 --exclude SC1091 - < "$script" && echo "OK"
 }
 export -f run_shellcheck
 
 find "$DIR" -type f ! -path "*.git/*" ! -name "*.py" \( \
   -perm +111 -or -name "*.sh" -or -wholename "*usr/local/share/env/*" -or -wholename "*usr/local/share/container/*" \
-\) | parallel run_shellcheck
+\) | parallel --no-notice --tag --tagstring "Linting {}:" run_shellcheck
 
 run_hadolint()
 {
   local dockerfile="$1"
-  echo "Linting '$dockerfile':";
-  docker run --rm -i lukasmartinelli/hadolint hadolint --ignore DL3008 --ignore DL3002 --ignore DL3003 --ignore DL4001 --ignore DL3007 --ignore SC2016 - < "$dockerfile"
-  echo
+  docker run --rm -i lukasmartinelli/hadolint hadolint --ignore DL3008 --ignore DL3002 --ignore DL3003 --ignore DL4001 --ignore DL3007 --ignore SC2016 - < "$dockerfile" && echo "OK"
 }
 export -f run_hadolint
 
-find "$DIR" -type f -name "Dockerfile*" ! -name "*.tmpl" | parallel run_hadolint
+find "$DIR" -type f -name "Dockerfile*" ! -name "*.tmpl" | parallel --no-notice --tag --tagstring "Linting {}:" run_hadolint
 
 # Run unit tests
 docker-compose -f docker-compose.yml -f docker-compose.test.yml run --rm tests
@@ -42,11 +38,11 @@ run_integration_tests()
 {
   local integration_docker_compose="$1"
   echo "Running integration tests for '$integration_docker_compose':"
-  docker-compose -f "$DIR/docker-compose.yml" -f "$integration_docker_compose" build --parallel integration_tests
-  docker-compose -f "$DIR/docker-compose.yml" -f "$integration_docker_compose" up --exit-code-from integration_tests integration_tests
-  docker-compose -f "$DIR/docker-compose.yml" -f "$integration_docker_compose" down -v local
+  docker-compose -f docker-compose.yml -f "$integration_docker_compose" build --parallel integration_tests
+  docker-compose -f docker-compose.yml -f "$integration_docker_compose" up --exit-code-from integration_tests integration_tests
+  docker-compose -f docker-compose.yml -f "$integration_docker_compose" down -v
 }
 export -f run_integration_tests
 
 # Run integration tests
-find "$DIR" -type f -path "*/tests/integration/docker-compose.yml" | parallel run_integration_tests
+find "$DIR" -type f -path "*/tests/integration/docker-compose.yml" | parallel --no-notice --tag --tagstring "Integration {}:" run_integration_tests

--- a/test.sh
+++ b/test.sh
@@ -20,7 +20,7 @@ export -f run_shellcheck
 
 find "$DIR" -type f ! -path "*.git/*" ! -name "*.py" \( \
   -perm +111 -or -name "*.sh" -or -wholename "*usr/local/share/env/*" -or -wholename "*usr/local/share/container/*" \
-\) | parallel --no-notice --tag --tagstring "Linting {}:" run_shellcheck
+\) | parallel --no-notice --line-buffer --tag --tagstring "Linting {}:" run_shellcheck
 
 run_hadolint()
 {
@@ -29,7 +29,7 @@ run_hadolint()
 }
 export -f run_hadolint
 
-find "$DIR" -type f -name "Dockerfile*" ! -name "*.tmpl" | parallel --no-notice --tag --tagstring "Linting {}:" run_hadolint
+find "$DIR" -type f -name "Dockerfile*" ! -name "*.tmpl" | parallel --no-notice --line-buffer --tag --tagstring "Linting {}:" run_hadolint
 
 # Run unit tests
 docker-compose -f docker-compose.yml -f docker-compose.test.yml run --rm tests
@@ -45,4 +45,4 @@ run_integration_tests()
 export -f run_integration_tests
 
 # Run integration tests
-find "$DIR" -type f -path "*/tests/integration/docker-compose.yml" | parallel --no-notice --tag --tagstring "Integration {}:" run_integration_tests
+find "$DIR" -type f -path "*/tests/integration/docker-compose.yml" | parallel --no-notice --line-buffer --tag --tagstring "Integration {}:" run_integration_tests

--- a/test.sh
+++ b/test.sh
@@ -11,26 +11,42 @@ fi
 docker pull koalaman/shellcheck:v0.4.6
 docker pull lukasmartinelli/hadolint
 
-find "$DIR" -type f ! -path "*.git/*" ! -name "*.py" \( \
-  -perm +111 -or -name "*.sh" -or -wholename "*usr/local/share/env/*" -or -wholename "*usr/local/share/container/*" \
-\) | while read -r script; do
+run_shellcheck()
+{
+  local script="$1"
   echo "Linting '$script':";
   docker run --rm -i koalaman/shellcheck:v0.4.6 --exclude SC1091 - < "$script";
   echo
-done
+}
+export -f run_shellcheck
 
-find "$DIR" -type f -name "Dockerfile*" ! -name "*.tmpl" | while read -r dockerfile; do
+find "$DIR" -type f ! -path "*.git/*" ! -name "*.py" \( \
+  -perm +111 -or -name "*.sh" -or -wholename "*usr/local/share/env/*" -or -wholename "*usr/local/share/container/*" \
+\) | parallel run_shellcheck
+
+run_hadolint()
+{
+  local dockerfile="$1"
   echo "Linting '$dockerfile':";
   docker run --rm -i lukasmartinelli/hadolint hadolint --ignore DL3008 --ignore DL3002 --ignore DL3003 --ignore DL4001 --ignore DL3007 --ignore SC2016 - < "$dockerfile"
   echo
-done
+}
+export -f run_hadolint
+
+find "$DIR" -type f -name "Dockerfile*" ! -name "*.tmpl" | parallel run_hadolint
 
 # Run unit tests
 docker-compose -f docker-compose.yml -f docker-compose.test.yml run --rm tests
 
-# Run integration tests
-find "$DIR" -type f -path "*/tests/integration/docker-compose.yml" | while read -r integration_docker_compose; do
+run_integration_tests()
+{
+  local integration_docker_compose="$1"
   echo "Running integration tests for '$integration_docker_compose':"
-  docker-compose -f "$DIR/docker-compose.yml" -f "$integration_docker_compose" up --build --exit-code-from integration_tests integration_tests;
-  docker-compose -f "$DIR/docker-compose.yml" -f "$integration_docker_compose" down -v --rmi local
-done
+  docker-compose -f "$DIR/docker-compose.yml" -f "$integration_docker_compose" build --parallel integration_tests
+  docker-compose -f "$DIR/docker-compose.yml" -f "$integration_docker_compose" up --exit-code-from integration_tests integration_tests
+  docker-compose -f "$DIR/docker-compose.yml" -f "$integration_docker_compose" down -v local
+}
+export -f run_integration_tests
+
+# Run integration tests
+find "$DIR" -type f -path "*/tests/integration/docker-compose.yml" | parallel run_integration_tests

--- a/test.sh
+++ b/test.sh
@@ -32,6 +32,7 @@ export -f run_hadolint
 find "$DIR" -type f -name "Dockerfile*" ! -name "*.tmpl" | parallel --no-notice --line-buffer --tag --tagstring "Linting {}:" run_hadolint
 
 # Run unit tests
+docker-compose -f docker-compose.yml -f docker-compose.test.yml build ubuntu
 docker-compose -f docker-compose.yml -f docker-compose.test.yml run --rm tests
 
 run_integration_tests()


### PR DESCRIPTION
1. Find any `*/tests/integration/docker-compose.yml` path
2. Run a build of the affected images
3. Bring up a mini-project to test that the docker image starts up successfully
4. Run tests against the mini-project

In the case of the PHP images - start the web server and check we can curl a phpinfo() page.