### PR TITLE
Full php-fpm error_log messages

### DIFF
--- a/php/nginx/etc/confd/templates/php-fpm/pool.conf.tmpl
+++ b/php/nginx/etc/confd/templates/php-fpm/pool.conf.tmpl
@@ -23,5 +23,5 @@ php_value[date.timezone] = {{ getenv "PHP_TIMEZONE" }}
 php_value[memory_limit] = {{ getenv "PHP_MEMORY_LIMIT" }}
 
 php_admin_value[display_errors] = Off
-php_admin_value[error_log] = /dev/stderr
+php_admin_value[error_log] = /var/log/php-fpm/stdout
 php_admin_flag[log_errors] = on

--- a/php/nginx/etc/confd/templates/supervisor/php-fpm.conf.tmpl
+++ b/php/nginx/etc/confd/templates/supervisor/php-fpm.conf.tmpl
@@ -10,3 +10,14 @@ user = root
 autostart = {{ getenv "START_PHP_FPM" }}
 autorestart = true
 priority = 5
+
+[program:php-fpm-logs]
+command = /usr/local/bin/container --no-debug tail_phpfpm_logs
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+user = {{ getenv "APP_USER" }}
+autostart = {{ getenv "START_PHP_FPM" }}
+autorestart = true
+priority = 5

--- a/php/nginx/usr/local/share/container/baseimage-21.sh
+++ b/php/nginx/usr/local/share/container/baseimage-21.sh
@@ -24,8 +24,11 @@ do_start() {
 
 do_phpfpm_named_pipe() {
   if [ ! -p /var/log/php-fpm/stdout ]; then
-    mkdir /var/log/php-fpm/
-    mkfifo /var/log/php-fpm/stdout
+    if [ -e /var/log/php-fpm/stdout ]; then
+      rm -f /var/log/php-fpm/stdout
+    fi
+    mkdir -p /var/log/php-fpm/
+    mkfifo -m 0660 /var/log/php-fpm/stdout
   fi
   chown -R "$APP_USER:$APP_GROUP" /var/log/php-fpm/
 }

--- a/php/nginx/usr/local/share/container/baseimage-21.sh
+++ b/php/nginx/usr/local/share/container/baseimage-21.sh
@@ -9,3 +9,28 @@ do_webserver() {
 do_webserver_reload() {
   supervisor_signal HUP nginx
 }
+
+alias_function do_build do_nginx_build_inner
+do_build() {
+  do_phpfpm_named_pipe
+  do_nginx_build_inner
+}
+
+alias_function do_start do_nginx_start_inner
+do_start() {
+  do_nginx_start_inner
+  do_phpfpm_named_pipe
+}
+
+do_phpfpm_named_pipe() {
+  if [ ! -p /var/log/php-fpm/stdout ]; then
+    mkdir /var/log/php-fpm/
+    mkfifo /var/log/php-fpm/stdout
+  fi
+  chown -R "$APP_USER:$APP_GROUP" /var/log/php-fpm/
+}
+
+do_tail_phpfpm_logs()
+{
+  cat 0<> /var/log/php-fpm/stdout
+}


### PR DESCRIPTION
Implement https://github.com/docker-library/php/issues/207#issuecomment-276296087 to get the raw php-fpm logs instead of entries with "pid XXX said in to stderr" prepended and truncated at 1024 characters.