### PR TITLE
Spryker: Turn off Xdebug during development_start

### DIFF
--- a/spryker/usr/local/share/container/baseimage-45.sh
+++ b/spryker/usr/local/share/container/baseimage-45.sh
@@ -22,17 +22,14 @@ do_start() {
 
 alias_function do_development_start do_spryker_development_start_inner
 do_development_start() {
-  local OLD_XDEBUG_REMOTE_ENABLED="$XDEBUG_REMOTE_ENABLED"
-  if is_true "$OLD_XDEBUG_REMOTE_ENABLED"; then
+  if is_true "$XDEBUG_REMOTE_ENABLED"; then
     XDEBUG_REMOTE_ENABLED=false do_templating
   fi
   do_spryker_development_start_inner
   do_spryker_build
   do_spryker_install
   do_spryker_app_permissions
-  if is_true "$OLD_XDEBUG_REMOTE_ENABLED"; then
-    do_templating
-  fi
+  do_templating
 }
 
 alias_function do_setup do_spryker_setup_inner

--- a/spryker/usr/local/share/container/baseimage-45.sh
+++ b/spryker/usr/local/share/container/baseimage-45.sh
@@ -22,10 +22,17 @@ do_start() {
 
 alias_function do_development_start do_spryker_development_start_inner
 do_development_start() {
+  local OLD_XDEBUG_REMOTE_ENABLED="$XDEBUG_REMOTE_ENABLED"
+  if is_true "$OLD_XDEBUG_REMOTE_ENABLED"; then
+    XDEBUG_REMOTE_ENABLED=false do_templating
+  fi
   do_spryker_development_start_inner
   do_spryker_build
   do_spryker_install
   do_spryker_app_permissions
+  if is_true "$OLD_XDEBUG_REMOTE_ENABLED"; then
+    do_templating
+  fi
 }
 
 alias_function do_setup do_spryker_setup_inner


### PR DESCRIPTION
The `vendor/bin/console propel:install` step can time out with Xdebug enabled.