### PR TITLE
Fix checks for the database existing if it doesn't exist yet

### DIFF
--- a/php/shared/usr/local/share/assets/assets_functions.sh
+++ b/php/shared/usr/local/share/assets/assets_functions.sh
@@ -107,6 +107,8 @@ function assets_apply_database_mysql()
   local DATABASE_TABLE_COUNT=0
   if [ "${DATABASE_EXISTS}" -eq 0 ]; then
     DATABASE_TABLES="$(mysql_list_tables "${APPLY_DATABASE_NAME}")"
+  fi
+  if [ -n "${DATABASE_TABLES}" ]; then
     DATABASE_TABLE_COUNT="$(echo "${DATABASE_TABLES}" | wc -l)"
   fi
 
@@ -150,6 +152,8 @@ function assets_apply_database_postgres()
   local DATABASE_TABLES
   if [ "${DATABASE_EXISTS}" -eq 0 ]; then
     DATABASE_TABLES="$(postgres_list_tables "${APPLY_DATABASE_NAME}")"
+  fi
+  if [ -n "${DATABASE_TABLES}" ]; then
     DATABASE_TABLE_COUNT="$(echo "${DATABASE_TABLES}" | wc -l)"
   fi
 

--- a/php/shared/usr/local/share/database/database_functions.sh
+++ b/php/shared/usr/local/share/database/database_functions.sh
@@ -65,11 +65,10 @@ mysql_database_exists()
     exit 1
   fi
 
-  set +e
-  echo "${DATABASES}" | grep --quiet --fixed-strings --line-regexp "${CHECK_DATABASE_NAME}"
+  (set +e && echo "${DATABASES}" | grep --quiet --fixed-strings --line-regexp "${CHECK_DATABASE_NAME}")
   local DATABASE_EXISTS="$?"
 
-  set -ex
+  set -x
   return "$DATABASE_EXISTS"
 }
 
@@ -92,11 +91,10 @@ postgres_database_exists()
     exit 1
   fi
 
-  set +e
-  echo "${DATABASES}" | grep --quiet --fixed-strings --line-regexp "${CHECK_DATABASE_NAME}"
+  (set +e && echo "${DATABASES}" | grep --quiet --fixed-strings --line-regexp "${CHECK_DATABASE_NAME}")
   local DATABASE_EXISTS="$?"
 
-  set -ex
+  set -x
   return "$DATABASE_EXISTS"
 }
 
@@ -162,7 +160,7 @@ mysql_list_tables()
   set +x
 
   local DATABASE_TABLES=""
-  DATABASE_TABLES="$(set -o pipefail && mysql "${DATABASE_ARGS[@]}" "${LIST_DATABASE_NAME}" -e "SHOW TABLES" | tail --lines=+2)"
+  DATABASE_TABLES="$(set -o pipefail && mysql "${DATABASE_ARGS[@]}" -e "SHOW TABLES" | tail --lines=+2)"
   # shellcheck disable=SC2181
   if [ "$?" -ne 0 ]; then
     echo "Failed to get a list of tables from '${LIST_DATABASE_NAME}', exiting."
@@ -221,10 +219,9 @@ mysql_has_table()
     exit 1
   fi
 
-  set +ex
-  echo "${DATABASE_TABLES}" | grep --quiet --fixed-strings --line-regexp "${TABLE_NAME}"
+  (set +ex && echo "${DATABASE_TABLES}" | grep --quiet --fixed-strings --line-regexp "${TABLE_NAME}")
   local TABLE_EXISTS="$?"
-  set -ex
+  set -x
   return "$TABLE_EXISTS"
 }
 
@@ -241,9 +238,8 @@ postgres_has_table()
     exit 1
   fi
 
-  set +ex
-  echo "${DATABASE_TABLES}" | grep --quiet --fixed-strings --line-regexp "${TABLE_NAME}"
+  (set +ex && echo "${DATABASE_TABLES}" | grep --quiet --fixed-strings --line-regexp "${TABLE_NAME}")
   local TABLE_EXISTS="$?"
-  set -ex
+  set -x
   return "$TABLE_EXISTS"
 }


### PR DESCRIPTION
`set -e` before returning stops it from being allowed to fail during
check for `mysql_database_exists` in `assets_apply_database_mysql`.

`echo "" | wc -l` is still 1 line, so database wasn't being installed
due to check for 0 lines.

`mysql_database_admin_args "${LIST_DATABASE_NAME}"` puts the database
name on the command line arguments already, so remove repitition that
was causing the mysql help text to appear during mysql_list_tables.