### PR TITLE
DEVOPS-695: fix for magento2 image

### DIFF
--- a/magento2/Dockerfile
+++ b/magento2/Dockerfile
@@ -51,3 +51,8 @@ WORKDIR /app
 
 COPY ./etc/ /etc/
 COPY ./usr/ /usr/
+RUN if [ "$REQUIRE_HEM" != "true" ]; \
+    then \
+        rm -f /etc/confd/conf.d/hem* \
+     && rm -rf /etc/confd/templates/hem ;\
+    fi


### PR DESCRIPTION
removes conf.d Hem template and config if Hem is not required in magento2 iamges