### PR TITLE
Save time with PHP image builds by sharing common layers

### DIFF
--- a/docker-compose.stable.yml
+++ b/docker-compose.stable.yml
@@ -124,6 +124,18 @@ services:
   piwik_php71_apache_stable:
     image: quay.io/continuouspipe/piwik-php7.1-apache:stable
     build: "/dev/null"
+  php72:
+    image: quay.io/continuouspipe/php7.2:stable
+    build: "/dev/null"
+  php71:
+    image: quay.io/continuouspipe/php7.1:stable
+    build: "/dev/null"
+  php70:
+    image: quay.io/continuouspipe/php7:stable
+    build: "/dev/null"
+  php56:
+    image: quay.io/continuouspipe/php5.6:stable
+    build: "/dev/null"
   php72_apache_stable:
     image: quay.io/continuouspipe/php7.2-apache:stable
     build: "/dev/null"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -364,6 +364,46 @@ services:
     depends_on:
       - php71_apache
 
+  php72:
+    build:
+      context: ./php/
+      dockerfile: Dockerfile-php
+      args:
+        PHP_VERSION: '7.2'
+    image: quay.io/continuouspipe/php7.2:latest
+    depends_on:
+      - ubuntu
+
+  php71:
+    build:
+      context: ./php/
+      dockerfile: Dockerfile-php
+      args:
+        PHP_VERSION: '7.1'
+    image: quay.io/continuouspipe/php7.1:latest
+    depends_on:
+      - ubuntu
+
+  php70:
+    build:
+      context: ./php/
+      dockerfile: Dockerfile-php
+      args:
+        PHP_VERSION: '7.0'
+    image: quay.io/continuouspipe/php7:latest
+    depends_on:
+      - ubuntu
+
+  php56:
+    build:
+      context: ./php/
+      dockerfile: Dockerfile-php
+      args:
+        PHP_VERSION: '5.6'
+    image: quay.io/continuouspipe/php5.6:latest
+    depends_on:
+      - ubuntu
+
   php72_apache:
     build:
       context: ./php/
@@ -372,7 +412,7 @@ services:
         PHP_VERSION: '7.2'
     image: quay.io/continuouspipe/php7.2-apache:latest
     depends_on:
-      - ubuntu
+      - php72
 
   php71_apache:
     build:
@@ -382,7 +422,7 @@ services:
         PHP_VERSION: '7.1'
     image: quay.io/continuouspipe/php7.1-apache:latest
     depends_on:
-      - ubuntu
+      - php71
 
   php70_apache:
     build:
@@ -392,7 +432,7 @@ services:
         PHP_VERSION: '7.0'
     image: quay.io/continuouspipe/php7-apache:latest
     depends_on:
-      - ubuntu
+      - php70
 
   php56_apache:
     build:
@@ -402,7 +442,7 @@ services:
         PHP_VERSION: '5.6'
     image: quay.io/continuouspipe/php5.6-apache:latest
     depends_on:
-      - ubuntu
+      - php56
 
   php72_nginx:
     build:
@@ -412,7 +452,7 @@ services:
         PHP_VERSION: '7.2'
     image: quay.io/continuouspipe/php7.2-nginx:latest
     depends_on:
-      - ubuntu
+      - php72
 
   php71_nginx:
     build:
@@ -422,7 +462,7 @@ services:
         PHP_VERSION: '7.1'
     image: quay.io/continuouspipe/php7.1-nginx:latest
     depends_on:
-      - ubuntu
+      - php71
 
   php70_nginx:
     build:
@@ -432,7 +472,7 @@ services:
         PHP_VERSION: '7.0'
     image: quay.io/continuouspipe/php7-nginx:latest
     depends_on:
-      - ubuntu
+      - php70
 
   php56_nginx:
     build:
@@ -442,7 +482,7 @@ services:
         PHP_VERSION: '5.6'
     image: quay.io/continuouspipe/php5.6-nginx:latest
     depends_on:
-      - ubuntu
+      - php56
 
   postgres94:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -409,7 +409,7 @@ services:
       context: ./php/
       dockerfile: Dockerfile-apache
       args:
-        PHP_VERSION: '7.2'
+        PHP_IMAGE_VERSION: '7.2'
     image: quay.io/continuouspipe/php7.2-apache:latest
     depends_on:
       - php72
@@ -419,7 +419,7 @@ services:
       context: ./php/
       dockerfile: Dockerfile-apache
       args:
-        PHP_VERSION: '7.1'
+        PHP_IMAGE_VERSION: '7.1'
     image: quay.io/continuouspipe/php7.1-apache:latest
     depends_on:
       - php71
@@ -429,7 +429,7 @@ services:
       context: ./php/
       dockerfile: Dockerfile-apache
       args:
-        PHP_VERSION: '7.0'
+        PHP_IMAGE_VERSION: '7'
     image: quay.io/continuouspipe/php7-apache:latest
     depends_on:
       - php70
@@ -439,7 +439,7 @@ services:
       context: ./php/
       dockerfile: Dockerfile-apache
       args:
-        PHP_VERSION: '5.6'
+        PHP_IMAGE_VERSION: '5.6'
     image: quay.io/continuouspipe/php5.6-apache:latest
     depends_on:
       - php56
@@ -449,7 +449,7 @@ services:
       context: ./php/
       dockerfile: Dockerfile-nginx
       args:
-        PHP_VERSION: '7.2'
+        PHP_IMAGE_VERSION: '7.2'
     image: quay.io/continuouspipe/php7.2-nginx:latest
     depends_on:
       - php72
@@ -459,7 +459,7 @@ services:
       context: ./php/
       dockerfile: Dockerfile-nginx
       args:
-        PHP_VERSION: '7.1'
+        PHP_IMAGE_VERSION: '7.1'
     image: quay.io/continuouspipe/php7.1-nginx:latest
     depends_on:
       - php71
@@ -469,7 +469,7 @@ services:
       context: ./php/
       dockerfile: Dockerfile-nginx
       args:
-        PHP_VERSION: '7.0'
+        PHP_IMAGE_VERSION: '7'
     image: quay.io/continuouspipe/php7-nginx:latest
     depends_on:
       - php70
@@ -479,7 +479,7 @@ services:
       context: ./php/
       dockerfile: Dockerfile-nginx
       args:
-        PHP_VERSION: '5.6'
+        PHP_IMAGE_VERSION: '5.6'
     image: quay.io/continuouspipe/php5.6-nginx:latest
     depends_on:
       - php56

--- a/php/Dockerfile-apache
+++ b/php/Dockerfile-apache
@@ -1,6 +1,6 @@
-ARG PHP_VERSION
+ARG PHP_IMAGE_VERSION
 ARG FROM_TAG=latest
-FROM quay.io/continuouspipe/php${PHP_VERSION}:${FROM_TAG}
+FROM quay.io/continuouspipe/php${PHP_IMAGE_VERSION}:${FROM_TAG}
 
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \

--- a/php/Dockerfile-apache
+++ b/php/Dockerfile-apache
@@ -1,64 +1,18 @@
-ARG FROM_TAG=latest
-FROM quay.io/continuouspipe/ubuntu16.04:${FROM_TAG}
-
-# Install PHP packages, including the Tideways extension
 ARG PHP_VERSION
-ENV PHP_VERSION ${PHP_VERSION:-7.0}
-RUN echo 'deb http://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages debian main' > /etc/apt/sources.list.d/tideways.list \
- && curl -sS https://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages/EEB5E8F4.gpg | apt-key add - \
- && if [ "$PHP_VERSION" != "7.0" ]; then \
-   echo 'deb http://ppa.launchpad.net/ondrej/php/ubuntu xenial main' > /etc/apt/sources.list.d/php-ppa.list; \
-   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E5267A6C; \
- fi \
- && apt-get update -qq \
+ARG FROM_TAG=latest
+FROM quay.io/continuouspipe/php${PHP_VERSION}:${FROM_TAG}
+
+RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
     apache2 \
     apache2-utils \
-    awscli \
-    curl \
-    git \
-    jq \
     "libapache2-mod-php$PHP_VERSION" \
-    php-apcu \
-    php-imagick \
-    php-memcached \
-    php-xdebug \
-    "php$PHP_VERSION-bcmath" \
-    "php$PHP_VERSION-bz2" \
-    "php$PHP_VERSION-curl" \
-    "php$PHP_VERSION-dev" \
-    "php$PHP_VERSION-gd" \
-    "php$PHP_VERSION-intl" \
-    "php$PHP_VERSION-mbstring" \
-    "$( dpkg --compare-versions "$PHP_VERSION" ge 7.2 || echo "php$PHP_VERSION-mcrypt" )" \
-    "php$PHP_VERSION-opcache" \
-    "php$PHP_VERSION-soap" \
-    "php$PHP_VERSION-xsl" \
-    "php$PHP_VERSION-zip" \
-    "php$PHP_VERSION-mysql" mysql-client \
-    "php$PHP_VERSION-pgsql" postgresql-client \
-    "php$PHP_VERSION-sqlite3" \
-    postfix \
-    tideways-php \
- # Install pear after PHP so the right CLI gets selected beforehand \
- && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
-    php-pear \
- \
- # php-redis 4 from php$PHP_VERSION-redis has backwards-incompatibilities so install from pecl repositories \
- && pecl install redis-3.1.6 \
- && echo -e '; priority=25\nextension=redis.so' | tee "/etc/php/${PHP_VERSION}/apache2/conf.d/25-redis.ini" > "/etc/php/${PHP_VERSION}/cli/conf.d/25-redis.ini" \
+ && echo -e '; priority=25\nextension=redis.so' > "/etc/php/${PHP_VERSION}/apache2/conf.d/25-redis.ini" \
  \
  # Clean the image \
- && apt-get remove -y "php$PHP_VERSION-dev" \
  && apt-get auto-remove -qq -y \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \
- \
- # Install composer for PHP dependencies \
- && wget https://getcomposer.org/installer -O /tmp/composer-setup.php -q \
- && [ "$(wget https://composer.github.io/installer.sig -O - -q)" = "$(sha384sum /tmp/composer-setup.php | awk '{ print $1 }')" ] \
- && php /tmp/composer-setup.php --install-dir='/usr/local/bin/' --filename='composer' --quiet \
- && rm /tmp/composer-setup.php \
  \
  # Enable the correct config for most sites \
  && a2disconf other-vhosts-access-log \
@@ -66,16 +20,8 @@ RUN echo 'deb http://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages debian m
  && a2enmod rewrite \
  && a2enmod ssl
 
-USER build
-
-RUN composer global require "hirak/prestissimo" --no-interaction --no-ansi --quiet --no-progress --prefer-dist \
- && composer clear-cache --no-ansi --quiet \
- && chmod -R go-w ~/.composer/vendor
-
-USER root
-
 # Add configuration
-COPY ./shared/etc/ ./apache/etc/ /etc/
-COPY ./shared/usr/ ./apache/usr/ /usr/
+COPY ./apache/etc/ /etc/
+COPY ./apache/usr/ /usr/
 
 RUN find /etc/confd/conf.d/ -name "*.toml" -type f -exec sed -i'' "s/\$PHP_VERSION/$PHP_VERSION/" {} \;

--- a/php/Dockerfile-nginx
+++ b/php/Dockerfile-nginx
@@ -1,6 +1,6 @@
-ARG PHP_VERSION
+ARG PHP_IMAGE_VERSION
 ARG FROM_TAG=latest
-FROM quay.io/continuouspipe/php${PHP_VERSION}:${FROM_TAG}
+FROM quay.io/continuouspipe/php${PHP_IMAGE_VERSION}:${FROM_TAG}
 
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \

--- a/php/Dockerfile-nginx
+++ b/php/Dockerfile-nginx
@@ -1,71 +1,19 @@
-ARG FROM_TAG=latest
-FROM quay.io/continuouspipe/ubuntu16.04:${FROM_TAG}
-
-# Install PHP packages, including the Tideways extension
 ARG PHP_VERSION
-ENV PHP_VERSION=${PHP_VERSION:-7.0}
-RUN echo 'deb http://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages debian main' > /etc/apt/sources.list.d/tideways.list \
- && curl -sS https://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages/EEB5E8F4.gpg | apt-key add - \
- && if [ "$PHP_VERSION" != "7.0" ]; then \
-   echo 'deb http://ppa.launchpad.net/ondrej/php/ubuntu xenial main' > /etc/apt/sources.list.d/php-ppa.list; \
-   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E5267A6C; \
- fi \
- && apt-get update -qq \
+ARG FROM_TAG=latest
+FROM quay.io/continuouspipe/php${PHP_VERSION}:${FROM_TAG}
+
+RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
-    awscli \
-    jq \
     nginx \
-    php-apcu \
-    php-imagick \
-    php-memcached \
-    php-xdebug \
-    "php$PHP_VERSION-bcmath" \
-    "php$PHP_VERSION-bz2" \
-    "php$PHP_VERSION-curl" \
-    "php$PHP_VERSION-dev" \
-    "php$PHP_VERSION-fpm" \
-    "php$PHP_VERSION-gd" \
-    "php$PHP_VERSION-intl" \
-    "php$PHP_VERSION-mbstring" \
-    "$( dpkg --compare-versions "$PHP_VERSION" ge 7.2 || echo "php$PHP_VERSION-mcrypt" )" \
-    "php$PHP_VERSION-opcache" \
-    "php$PHP_VERSION-soap" \
-    "php$PHP_VERSION-xsl" \
-    "php$PHP_VERSION-zip" \
-    "php$PHP_VERSION-mysql" mysql-client \
-    "php$PHP_VERSION-pgsql" postgresql-client \
-    "php$PHP_VERSION-sqlite3" \
-    postfix \
-    tideways-php \
- # Install pear after PHP so the right CLI gets selected beforehand \
- && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
-    php-pear \
  \
- # php-redis 4 from php$PHP_VERSION-redis has backwards-incompatibilities so install from pecl repositories \
- && pecl install redis-3.1.6 \
- && echo -e '; priority=25\nextension=redis.so' | tee "/etc/php/${PHP_VERSION}/fpm/conf.d/25-redis.ini" > "/etc/php/${PHP_VERSION}/cli/conf.d/25-redis.ini" \
+ && echo -e '; priority=25\nextension=redis.so' > "/etc/php/${PHP_VERSION}/fpm/conf.d/25-redis.ini" \
  \
  # Clean the image \
- && apt-get remove -y "php$PHP_VERSION-dev" \
  && apt-get auto-remove -qq -y \
  && apt-get clean \
- && rm -rf /var/lib/apt/lists/* \
- \
- # Install composer for PHP dependencies \
- && wget https://getcomposer.org/installer -O /tmp/composer-setup.php -q \
- && [ "$(wget https://composer.github.io/installer.sig -O - -q)" = "$(sha384sum /tmp/composer-setup.php | awk '{ print $1 }')" ] \
- && php /tmp/composer-setup.php --install-dir='/usr/local/bin/' --filename='composer' --quiet \
- && rm /tmp/composer-setup.php
+ && rm -rf /var/lib/apt/lists/*
 
-USER build
-
-RUN composer global require "hirak/prestissimo" --no-interaction --no-ansi --quiet --no-progress --prefer-dist \
- && composer clear-cache --no-ansi --quiet \
- && chmod -R go-w ~/.composer/vendor
-
-USER root
-
-COPY ./shared/etc/ ./nginx/etc/ /etc/
-COPY ./shared/usr/ ./nginx/usr/ /usr/
+COPY ./nginx/etc/ /etc/
+COPY ./nginx/usr/ /usr/
 
 RUN find /etc/confd/conf.d/ -name "*.toml" -type f -exec sed -i'' "s/\$PHP_VERSION/$PHP_VERSION/" {} \;

--- a/php/Dockerfile-nginx
+++ b/php/Dockerfile-nginx
@@ -5,6 +5,7 @@ FROM quay.io/continuouspipe/php${PHP_VERSION}:${FROM_TAG}
 RUN apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
     nginx \
+    "php$PHP_VERSION-fpm" \
  \
  && echo -e '; priority=25\nextension=redis.so' > "/etc/php/${PHP_VERSION}/fpm/conf.d/25-redis.ini" \
  \

--- a/php/Dockerfile-php
+++ b/php/Dockerfile-php
@@ -1,0 +1,69 @@
+ARG FROM_TAG=latest
+FROM quay.io/continuouspipe/ubuntu16.04:${FROM_TAG}
+
+# Install PHP packages, including the Tideways extension
+ARG PHP_VERSION
+ENV PHP_VERSION=${PHP_VERSION:-7.0}
+RUN echo 'deb http://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages debian main' > /etc/apt/sources.list.d/tideways.list \
+ && curl -sS https://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages/EEB5E8F4.gpg | apt-key add - \
+ && if [ "$PHP_VERSION" != "7.0" ]; then \
+   echo 'deb http://ppa.launchpad.net/ondrej/php/ubuntu xenial main' > /etc/apt/sources.list.d/php-ppa.list; \
+   apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E5267A6C; \
+ fi \
+ && apt-get update -qq \
+ && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
+    awscli \
+    jq \
+    php-apcu \
+    php-imagick \
+    php-memcached \
+    php-xdebug \
+    "php$PHP_VERSION-bcmath" \
+    "php$PHP_VERSION-bz2" \
+    "php$PHP_VERSION-curl" \
+    "php$PHP_VERSION-dev" \
+    "php$PHP_VERSION-gd" \
+    "php$PHP_VERSION-intl" \
+    "php$PHP_VERSION-mbstring" \
+    "$( dpkg --compare-versions "$PHP_VERSION" ge 7.2 || echo "php$PHP_VERSION-mcrypt" )" \
+    "php$PHP_VERSION-opcache" \
+    "php$PHP_VERSION-soap" \
+    "php$PHP_VERSION-xsl" \
+    "php$PHP_VERSION-zip" \
+    "php$PHP_VERSION-mysql" mysql-client \
+    "php$PHP_VERSION-pgsql" postgresql-client \
+    "php$PHP_VERSION-sqlite3" \
+    postfix \
+    tideways-php \
+ # Install pear after PHP so the right CLI gets selected beforehand \
+ && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
+    php-pear \
+ \
+ # php-redis 4 from php$PHP_VERSION-redis has backwards-incompatibilities so install from pecl repositories \
+ && pecl install redis-3.1.6 \
+ && echo -e '; priority=25\nextension=redis.so' > "/etc/php/${PHP_VERSION}/cli/conf.d/25-redis.ini" \
+ \
+ # Clean the image \
+ && apt-get remove -y "php$PHP_VERSION-dev" \
+ && apt-get auto-remove -qq -y \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
+ \
+ # Install composer for PHP dependencies \
+ && wget https://getcomposer.org/installer -O /tmp/composer-setup.php -q \
+ && [ "$(wget https://composer.github.io/installer.sig -O - -q)" = "$(sha384sum /tmp/composer-setup.php | awk '{ print $1 }')" ] \
+ && php /tmp/composer-setup.php --install-dir='/usr/local/bin/' --filename='composer' --quiet \
+ && rm /tmp/composer-setup.php
+
+USER build
+
+RUN composer global require "hirak/prestissimo" --no-interaction --no-ansi --quiet --no-progress --prefer-dist \
+ && composer clear-cache --no-ansi --quiet \
+ && chmod -R go-w ~/.composer/vendor
+
+USER root
+
+COPY ./shared/etc/ /etc/
+COPY ./shared/usr/ /usr/
+
+RUN find /etc/confd/conf.d/ -name "*.toml" -type f -exec sed -i'' "s/\$PHP_VERSION/$PHP_VERSION/" {} \;

--- a/php/Dockerfile-php
+++ b/php/Dockerfile-php
@@ -14,10 +14,6 @@ RUN echo 'deb http://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages debian m
  && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
     awscli \
     jq \
-    php-apcu \
-    php-imagick \
-    php-memcached \
-    php-xdebug \
     "php$PHP_VERSION-bcmath" \
     "php$PHP_VERSION-bz2" \
     "php$PHP_VERSION-curl" \
@@ -35,9 +31,13 @@ RUN echo 'deb http://s3-eu-west-1.amazonaws.com/qafoo-profiler/packages debian m
     "php$PHP_VERSION-sqlite3" \
     postfix \
     tideways-php \
- # Install pear after PHP so the right CLI gets selected beforehand \
+ # Install pear + pecl extensions after PHP so the right CLI gets selected beforehand \
  && DEBIAN_FRONTEND=noninteractive apt-get -qq -y --no-install-recommends install \
+    php-apcu \
+    php-imagick \
+    php-memcached \
     php-pear \
+    php-xdebug \
  \
  # php-redis 4 from php$PHP_VERSION-redis has backwards-incompatibilities so install from pecl repositories \
  && pecl install redis-3.1.6 \


### PR DESCRIPTION
Build a PHP CLI image and then layer NGINX/Apache on top, means we run the travis build including integration tests in 13 minutes instead of 19 minutes:
https://travis-ci.org/continuouspipe/dockerfiles/builds/449264950 vs https://travis-ci.org/continuouspipe/dockerfiles/builds/449106233

Does mean some extra layers but modern docker seems okay with them.