### PR TITLE
Travis build log folding + exit code catching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ before_install:
   - docker-compose --version
   - docker pull koalaman/shellcheck:v0.4.6
   - docker pull lukasmartinelli/hadolint:latest
-  - docker pull quay.io/continuouspipe/ubuntu16.04:latest
   - curl -L https://github.com/docker/compose/releases/download/1.23.0-rc3/docker-compose-`uname -s`-`uname -m` -o docker-compose
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin/

--- a/build.sh
+++ b/build.sh
@@ -209,9 +209,14 @@ main()
     }
   else
     for level in 3 2 1 0; do
+      echo "travis_fold:start:build_level_$level"
       parallel --no-notice --line-buffer --tag --link ::: run_build run_publish ::: "$level" "$((level + 1))"
+      echo "travis_fold:end:build_level_$level"
     done
+
+    echo "travis_fold:start:push_level_0"
     run_publish 0
+    echo "travis_fold:end:push_level_0"
   fi
   echo "Done!"
 }

--- a/build.sh
+++ b/build.sh
@@ -171,6 +171,7 @@ export -f variables
 
 run_build()
 (
+  set -e
   local level="$1"
   time {
     variables "$level"
@@ -181,6 +182,7 @@ export -f run_build
 
 run_publish()
 (
+  set -e
   local level="$1"
   if [ "$level" -gt 3 ]; then
     return 0;

--- a/test.sh
+++ b/test.sh
@@ -18,9 +18,11 @@ run_shellcheck()
 }
 export -f run_shellcheck
 
+echo "travis_fold:start:lint_scripts"
 find "$DIR" -type f ! -path "*.git/*" ! -name "*.py" \( \
   -perm +111 -or -name "*.sh" -or -wholename "*usr/local/share/env/*" -or -wholename "*usr/local/share/container/*" \
 \) | parallel --no-notice --line-buffer --tag --tagstring "Linting {}:" run_shellcheck
+echo "travis_fold:end:lint_scripts"
 
 run_hadolint()
 {
@@ -29,11 +31,17 @@ run_hadolint()
 }
 export -f run_hadolint
 
+echo "travis_fold:start:lint_dockerfiles"
 find "$DIR" -type f -name "Dockerfile*" ! -name "*.tmpl" | parallel --no-notice --line-buffer --tag --tagstring "Linting {}:" run_hadolint
+echo "travis_fold:end:lint_dockerfiles"
 
 # Run unit tests
+echo "travis_fold:start:build_ubuntu_image"
 docker-compose -f docker-compose.yml -f docker-compose.test.yml build ubuntu
+echo "travis_fold:end:build_ubuntu_image"
+echo "travis_fold:start:unit_tests"
 docker-compose -f docker-compose.yml -f docker-compose.test.yml run --rm tests
+echo "travis_fold:end:unit_tests"
 
 run_integration_tests()
 {
@@ -45,5 +53,7 @@ run_integration_tests()
 }
 export -f run_integration_tests
 
+echo "travis_fold:start:integration_tests"
 # Run integration tests
 find "$DIR" -type f -path "*/tests/integration/docker-compose.yml" | parallel --no-notice --line-buffer --tag --tagstring "Integration {}:" run_integration_tests
+echo "travis_fold:end:integration_tests"

--- a/test.sh
+++ b/test.sh
@@ -8,52 +8,63 @@ else
     DIR="$(dirname "$0")"
 fi
 
-docker pull koalaman/shellcheck:v0.4.6
-docker pull lukasmartinelli/hadolint
+echo "travis_fold:start:pull_test_images"
+time docker pull koalaman/shellcheck:v0.4.6
+time docker pull lukasmartinelli/hadolint:latest
+echo "travis_fold:end:pull_test_images"
 
 run_shellcheck()
 {
+  set -e
   local script="$1"
   docker run --rm -i koalaman/shellcheck:v0.4.6 --exclude SC1091 - < "$script" && echo "OK"
 }
 export -f run_shellcheck
 
 echo "travis_fold:start:lint_scripts"
-find "$DIR" -type f ! -path "*.git/*" ! -name "*.py" \( \
-  -perm +111 -or -name "*.sh" -or -wholename "*usr/local/share/env/*" -or -wholename "*usr/local/share/container/*" \
-\) | parallel --no-notice --line-buffer --tag --tagstring "Linting {}:" run_shellcheck
+time {
+  find "$DIR" -type f ! -path "*.git/*" ! -name "*.py" \( \
+    -perm +111 -or -name "*.sh" -or -wholename "*usr/local/share/env/*" -or -wholename "*usr/local/share/container/*" \
+  \) | parallel --no-notice --line-buffer --tag --tagstring "Linting {}:" run_shellcheck
+}
 echo "travis_fold:end:lint_scripts"
 
 run_hadolint()
 {
+  set -e
   local dockerfile="$1"
-  docker run --rm -i lukasmartinelli/hadolint hadolint --ignore DL3008 --ignore DL3002 --ignore DL3003 --ignore DL4001 --ignore DL3007 --ignore SC2016 - < "$dockerfile" && echo "OK"
+  docker run --rm -i lukasmartinelli/hadolint:latest hadolint --ignore DL3008 --ignore DL3002 --ignore DL3003 --ignore DL4001 --ignore DL3007 --ignore SC2016 - < "$dockerfile" && echo "OK"
 }
 export -f run_hadolint
 
 echo "travis_fold:start:lint_dockerfiles"
-find "$DIR" -type f -name "Dockerfile*" ! -name "*.tmpl" | parallel --no-notice --line-buffer --tag --tagstring "Linting {}:" run_hadolint
+time {
+  find "$DIR" -type f -name "Dockerfile*" ! -name "*.tmpl" | parallel --no-notice --line-buffer --tag --tagstring "Linting {}:" run_hadolint
+}
 echo "travis_fold:end:lint_dockerfiles"
 
 # Run unit tests
 echo "travis_fold:start:build_ubuntu_image"
-docker-compose -f docker-compose.yml -f docker-compose.test.yml build ubuntu
+time docker-compose -f docker-compose.yml -f docker-compose.test.yml build --pull ubuntu
 echo "travis_fold:end:build_ubuntu_image"
 echo "travis_fold:start:unit_tests"
-docker-compose -f docker-compose.yml -f docker-compose.test.yml run --rm tests
+time docker-compose -f docker-compose.yml -f docker-compose.test.yml run --rm tests
 echo "travis_fold:end:unit_tests"
 
 run_integration_tests()
 {
+  set -e
   local integration_docker_compose="$1"
   echo "Running integration tests for '$integration_docker_compose':"
-  docker-compose -f docker-compose.yml -f "$integration_docker_compose" build --parallel integration_tests
-  docker-compose -f docker-compose.yml -f "$integration_docker_compose" up --exit-code-from integration_tests integration_tests
-  docker-compose -f docker-compose.yml -f "$integration_docker_compose" down -v
+  time docker-compose -f docker-compose.yml -f "$integration_docker_compose" build --parallel integration_tests
+  time docker-compose -f docker-compose.yml -f "$integration_docker_compose" up --exit-code-from integration_tests integration_tests
+  time docker-compose -f docker-compose.yml -f "$integration_docker_compose" down -v
 }
 export -f run_integration_tests
 
 echo "travis_fold:start:integration_tests"
 # Run integration tests
-find "$DIR" -type f -path "*/tests/integration/docker-compose.yml" | parallel --no-notice --line-buffer --tag --tagstring "Integration {}:" run_integration_tests
+time {
+  find "$DIR" -type f -path "*/tests/integration/docker-compose.yml" | parallel --no-notice --line-buffer --tag --tagstring "Integration {}:" run_integration_tests
+}
 echo "travis_fold:end:integration_tests"


### PR DESCRIPTION
Since moving to parallel, some exit codes were hidden as the global `set -e` doesn't apply to exported bash functions.