### PR TITLE
Magento1: Enable SQL profiler for developer mode

### DIFF
--- a/magento1/etc/confd/templates/magento/local.xml.tmpl
+++ b/magento1/etc/confd/templates/magento/local.xml.tmpl
@@ -33,6 +33,9 @@
                     <initStatements><![CDATA[SET NAMES utf8]]></initStatements>
                     <type><![CDATA[pdo_mysql]]></type>
                     <password><![CDATA[{{ getenv "DATABASE_PASSWORD" }}]]></password>
+                    {{ if eq "developer" (getenv "MAGENTO_MODE") }}
+                    <profiler><![CDATA[1]]></profiler>
+                    {{ end }}
                 </connection>
             </default_setup>
         </resources>


### PR DESCRIPTION
When Magento1 is in developer mode, enable the SQL profiler.