### PR TITLE
Fix debian:jessie based images as it's now in LTS with new repo locations

### DIFF
--- a/couchdb/Dockerfile
+++ b/couchdb/Dockerfile
@@ -1,7 +1,14 @@
 ARG FROM_TAG
 FROM couchdb:${FROM_TAG}
 
-RUN apt-get update -qq \
+ARG FROM_TAG
+RUN if [ "$FROM_TAG" = "1.6" ]; then \
+    echo "deb http://deb.debian.org/debian/ jessie main" > /etc/apt/sources.list \
+    && echo "deb http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list \
+    && echo "Acquire::Check-Valid-Until false;" >> /etc/apt/apt.conf.d/10-nocheckvalid \
+    && echo 'Package: *\nPin: origin "archive.debian.org"\nPin-Priority: 500' >> /etc/apt/preferences.d/10-archive-pin; \
+ fi \
+ && apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -s dist-upgrade | grep "^Inst" | \
       grep -i securi | awk -F " " '{print $2}' | \
       xargs apt-get -qq -y --no-install-recommends install \

--- a/elasticsearch/Dockerfile-dockerhub
+++ b/elasticsearch/Dockerfile-dockerhub
@@ -1,7 +1,16 @@
 ARG FROM_TAG
 FROM elasticsearch:${FROM_TAG}
 
-RUN apt-get update -qq \
+ARG FROM_TAG
+RUN if [ "$FROM_TAG" = "1.7" ]; then \
+    echo "deb http://deb.debian.org/debian/ jessie main" > /etc/apt/sources.list \
+    && echo "deb http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list \
+    && echo "deb http://archive.debian.org/debian/ jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list \
+    && echo "deb-src http://archive.debian.org/debian/ jessie-backports main" >> /etc/apt/sources.list.d/jessie-backports.list \
+    && echo "Acquire::Check-Valid-Until false;" >> /etc/apt/apt.conf.d/10-nocheckvalid \
+    && echo 'Package: *\nPin: origin "archive.debian.org"\nPin-Priority: 500' >> /etc/apt/preferences.d/10-archive-pin; \
+ fi \
+ && apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -s dist-upgrade | grep "^Inst" | \
       grep -i securi | awk -F " " '{print $2}' | \
       xargs apt-get -qq -y --no-install-recommends install \

--- a/solr/4.10/Dockerfile
+++ b/solr/4.10/Dockerfile
@@ -2,7 +2,13 @@ FROM makuk66/docker-solr:4.10.4
 
 USER root
 
-RUN apt-get update -qq \
+RUN echo "deb http://deb.debian.org/debian/ jessie main" > /etc/apt/sources.list \
+ && echo "deb http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list \
+ && echo "deb http://archive.debian.org/debian/ jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list \
+ && echo "deb-src http://archive.debian.org/debian/ jessie-backports main" >> /etc/apt/sources.list.d/jessie-backports.list \
+ && echo "Acquire::Check-Valid-Until false;" >> /etc/apt/apt.conf.d/10-nocheckvalid \
+ && echo 'Package: *\nPin: origin "archive.debian.org"\nPin-Priority: 500' >> /etc/apt/preferences.d/10-archive-pin \
+ && apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -s dist-upgrade | grep "^Inst" | \
       grep -i securi | awk -F " " '{print $2}' | \
       xargs apt-get -qq -y --no-install-recommends install \

--- a/solr/6.2/Dockerfile
+++ b/solr/6.2/Dockerfile
@@ -2,7 +2,13 @@ FROM solr:6.2
 
 USER root
 
-RUN apt-get update -qq \
+RUN echo "deb http://deb.debian.org/debian/ jessie main" > /etc/apt/sources.list \
+ && echo "deb http://security.debian.org/ jessie/updates main" >> /etc/apt/sources.list \
+ && echo "deb http://archive.debian.org/debian/ jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list \
+ && echo "deb-src http://archive.debian.org/debian/ jessie-backports main" >> /etc/apt/sources.list.d/jessie-backports.list \
+ && echo "Acquire::Check-Valid-Until false;" >> /etc/apt/apt.conf.d/10-nocheckvalid \
+ && echo 'Package: *\nPin: origin "archive.debian.org"\nPin-Priority: 500' >> /etc/apt/preferences.d/10-archive-pin \
+ && apt-get update -qq \
  && DEBIAN_FRONTEND=noninteractive apt-get -s dist-upgrade | grep "^Inst" | \
       grep -i securi | awk -F " " '{print $2}' | \
       xargs apt-get -qq -y --no-install-recommends install \

--- a/test.sh
+++ b/test.sh
@@ -35,7 +35,7 @@ run_hadolint()
 {
   set -e
   local dockerfile="$1"
-  docker run --rm -i lukasmartinelli/hadolint:latest hadolint --ignore DL3008 --ignore DL3002 --ignore DL3003 --ignore DL4001 --ignore DL3007 --ignore SC2016 - < "$dockerfile" && echo "OK"
+  docker run --rm -i lukasmartinelli/hadolint:latest hadolint --ignore DL3008 --ignore DL3002 --ignore DL3003 --ignore DL4001 --ignore DL3007 --ignore SC2016 --ignore SC2028 - < "$dockerfile" && echo "OK"
 }
 export -f run_hadolint
 


### PR DESCRIPTION
Changes occurred to the debian mirrors on 23rd March 2019 (after being announced here: https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html ):
* The jessie "updates" repository has been removed completely
* The jessie "backports" repository has been archived (and is no longer supported)
* The jessie "security" repository has been taken over by the LTS team (where not all packages will continue getting updates, depending on donations).

See https://wiki.debian.org/DebianJessie

Affected external images:
* couchdb:1.6
* elasticsearch:1.7
* makuk66/docker-solr:4.10.4
* solr:6.2