### PR TITLE
Update advice on stable vs latest image

### DIFF
--- a/couchdb/README.md
+++ b/couchdb/README.md
@@ -5,7 +5,7 @@ In a docker-compose.yml:
 version: '3'
 services:
   database:
-    image: quay.io/continuouspipe/couchdb1.6:stable
+    image: quay.io/continuouspipe/couchdb1.6:latest
     environment:
       COUCHDB_USER: "myAdminUser"
       COUCHDB_PASSWORD: "A secret password for myAdminUser"
@@ -13,7 +13,7 @@ services:
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/couchdb1.6:stable
+FROM quay.io/continuouspipe/couchdb1.6:latest
 ```
 
 ## How to build

--- a/drupal/README.md
+++ b/drupal/README.md
@@ -2,7 +2,7 @@
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/drupal-php7.1-apache:stable
+FROM quay.io/continuouspipe/drupal-php7.1-apache:latest
 ARG GITHUB_TOKEN=
 
 COPY . /app
@@ -10,7 +10,7 @@ RUN container build
 ```
 
 ```Dockerfile
-FROM quay.io/continuouspipe/drupal-php7-apache:stable
+FROM quay.io/continuouspipe/drupal-php7-apache:latest
 ARG GITHUB_TOKEN=
 
 COPY . /app
@@ -18,7 +18,7 @@ RUN container build
 ```
 
 ```Dockerfile
-FROM quay.io/continuouspipe/drupal-php5.6-apache:stable
+FROM quay.io/continuouspipe/drupal-php5.6-apache:latest
 ARG GITHUB_TOKEN=
 
 COPY . /app

--- a/drupal8-solr/4.10/README.md
+++ b/drupal8-solr/4.10/README.md
@@ -5,7 +5,7 @@ In a docker-compose.yml:
 version: '3'
 services:
   solr:
-    image: quay.io/continuouspipe/drupal8-solr4:stable
+    image: quay.io/continuouspipe/drupal8-solr4:latest
     volumes:
       - solr_data:/usr/local/share/solr/d8/data/
 
@@ -19,7 +19,7 @@ volumes:
 ```
 
 ```Dockerfile
-FROM quay.io/continuouspipe/drupal8-solr4:stable
+FROM quay.io/continuouspipe/drupal8-solr4:latest
 ```
 
 ## How to build

--- a/drupal8-solr/6.2/README.md
+++ b/drupal8-solr/6.2/README.md
@@ -5,7 +5,7 @@ In a docker-compose.yml:
 version: '3'
 services:
   solr:
-    image: quay.io/continuouspipe/drupal8-solr6:stable
+    image: quay.io/continuouspipe/drupal8-solr6:latest
     volumes:
       - solr_data:/usr/local/share/solr/d8/data/
 
@@ -19,7 +19,7 @@ volumes:
 ```
 
 ```Dockerfile
-FROM quay.io/continuouspipe/drupal8-solr6:stable
+FROM quay.io/continuouspipe/drupal8-solr6:latest
 ```
 
 ## How to build

--- a/drupal8-varnish/4.0/README.md
+++ b/drupal8-varnish/4.0/README.md
@@ -5,14 +5,14 @@ In a docker-compose.yml:
 version: '3'
 services:
   varnish:
-    image: quay.io/continuouspipe/drupal8-varnish4:stable
+    image: quay.io/continuouspipe/drupal8-varnish4:latest
     environment:
       VARNISH_SECRET: "A secret that should remain secret!"
 ```
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/drupal8-varnish4:stable
+FROM quay.io/continuouspipe/drupal8-varnish4:latest
 ```
 
 ## How to build

--- a/elasticsearch/README.md
+++ b/elasticsearch/README.md
@@ -5,7 +5,7 @@ In a docker-compose.yml for 5.6:
 version: '3'
 services:
   elasticsearch:
-    image: quay.io/continuouspipe/elasticsearch5.6:stable
+    image: quay.io/continuouspipe/elasticsearch5.6:latest
 ```
 
 In a docker-compose.yml for 5.5:
@@ -13,38 +13,38 @@ In a docker-compose.yml for 5.5:
 version: '3'
 services:
   elasticsearch:
-    image: quay.io/continuouspipe/elasticsearch5.5:stable
+    image: quay.io/continuouspipe/elasticsearch5.5:latest
 ```
 or 2.4:
 ```yml
 version: '3'
 services:
   elasticsearch:
-    image: quay.io/continuouspipe/elasticsearch2.4:stable
+    image: quay.io/continuouspipe/elasticsearch2.4:latest
 ```
 or 1.7:
 ```yml
 version: '3'
 services:
   elasticsearch:
-    image: quay.io/continuouspipe/elasticsearch1.7:stable
+    image: quay.io/continuouspipe/elasticsearch1.7:latest
 ```
 
 In a Dockerfile for 5.6:
 ```Dockerfile
-FROM quay.io/continuouspipe/elasticsearch5.6:stable
+FROM quay.io/continuouspipe/elasticsearch5.6:latest
 ```
 or 5.5:
 ```Dockerfile
-FROM quay.io/continuouspipe/elasticsearch5.5:stable
+FROM quay.io/continuouspipe/elasticsearch5.5:latest
 ```
 or 2.4:
 ```Dockerfile
-FROM quay.io/continuouspipe/elasticsearch2.4:stable
+FROM quay.io/continuouspipe/elasticsearch2.4:latest
 ```
 or 1.7:
 ```Dockerfile
-FROM quay.io/continuouspipe/elasticsearch1.7:stable
+FROM quay.io/continuouspipe/elasticsearch1.7:latest
 ```
 
 ## How to build

--- a/ezplatform/README.md
+++ b/ezplatform/README.md
@@ -2,7 +2,7 @@
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/ez6-apache-php7:stable
+FROM quay.io/continuouspipe/ez6-apache-php7:latest
 
 COPY . /app
 

--- a/hem/README.md
+++ b/hem/README.md
@@ -5,7 +5,7 @@ In a docker-compose.yml:
 version: '3'
 services:
   hem:
-    image: quay.io/continuouspipe/hem1:stable
+    image: quay.io/continuouspipe/hem1:latest
     environment:
       AWS_ACCESS_KEY_ID: "An AWS User ID that should remain secret!"
       AWS_SECRET_ACCESS_KEY: "An AWS Secret Key that should remain secret!"
@@ -13,7 +13,7 @@ services:
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/hem:stable
+FROM quay.io/continuouspipe/hem:latest
 
 ARG AWS_ACCESS_KEY_ID=
 ARG AWS_SECRET_ACCESS_KEY=

--- a/magento1/README.md
+++ b/magento1/README.md
@@ -2,7 +2,7 @@
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/magento1-nginx-php5.6:stable
+FROM quay.io/continuouspipe/magento1-nginx-php5.6:latest
 
 ARG GITHUB_TOKEN=
 
@@ -13,7 +13,7 @@ RUN container build
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/magento1-apache-php5.6:stable
+FROM quay.io/continuouspipe/magento1-apache-php5.6:latest
 
 ARG GITHUB_TOKEN=
 

--- a/magento2-varnish/4.0/README.md
+++ b/magento2-varnish/4.0/README.md
@@ -5,14 +5,14 @@ In a docker-compose.yml:
 version: '3'
 services:
   varnish:
-    image: quay.io/continuouspipe/magento2-varnish4:stable
+    image: quay.io/continuouspipe/magento2-varnish4:latest
     environment:
       VARNISH_SECRET: "A secret for varnish that should be kept secret!"
 ```
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/magento2-varnish4:stable
+FROM quay.io/continuouspipe/magento2-varnish4:latest
 ```
 
 ## How to build

--- a/mailcatcher/README.md
+++ b/mailcatcher/README.md
@@ -5,7 +5,7 @@ In a docker-compose.yml:
 version: '3'
 services:
   mailcatcher:
-    image: quay.io/continuouspipe/mailcatcher:stable
+    image: quay.io/continuouspipe/mailcatcher:latest
     extra_hosts:
       - "mailcatcher:127.0.0.1"
     expose:
@@ -16,7 +16,7 @@ services:
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/mailcatcher:stable
+FROM quay.io/continuouspipe/mailcatcher:latest
 ```
 
 ## How to build:

--- a/memcached/1.4/README.md
+++ b/memcached/1.4/README.md
@@ -5,12 +5,12 @@ In a docker-compose.yml:
 version: '3'
 services:
   memcached:
-    image: quay.io/continuouspipe/memcached1.4:stable
+    image: quay.io/continuouspipe/memcached1.4:latest
 ```
 
 In a Dockerfile
 ```Dockerfile
-FROM quay.io/continuouspipe/memcached1.4:stable
+FROM quay.io/continuouspipe/memcached1.4:latest
 ```
 
 ## How to build

--- a/mongodb/README.md
+++ b/mongodb/README.md
@@ -5,7 +5,7 @@ In a docker-compose.yml for mongodb3.6:
 version: '3'
 services:
   database:
-    image: quay.io/continuouspipe/mongodb3.6:stable
+    image: quay.io/continuouspipe/mongodb3.6:latest
     environment:
       MONGODB_AUTH_ENABLED: 1
       MONGODB_ADMIN_USER: "myAdminUser"
@@ -17,7 +17,7 @@ In a docker-compose.yml for mongodb3.4:
 version: '3'
 services:
   database:
-    image: quay.io/continuouspipe/mongodb3.4:stable
+    image: quay.io/continuouspipe/mongodb3.4:latest
     environment:
       MONGODB_AUTH_ENABLED: 1
       MONGODB_ADMIN_USER: "myAdminUser"
@@ -26,11 +26,11 @@ services:
 
 In a Dockerfile for 3.6:
 ```Dockerfile
-FROM quay.io/continuouspipe/mongodb3.6:stable
+FROM quay.io/continuouspipe/mongodb3.6:latest
 ```
 or for 3.4:
 ```Dockerfile
-FROM quay.io/continuouspipe/mongodb3.4:stable
+FROM quay.io/continuouspipe/mongodb3.4:latest
 ```
 
 ## How to build

--- a/mysql/README.md
+++ b/mysql/README.md
@@ -5,7 +5,7 @@ In a docker-compose.yml:
 version: '3'
 services:
   database:
-    image: quay.io/continuouspipe/mysql8.0:stable
+    image: quay.io/continuouspipe/mysql8.0:latest
     environment:
       MYSQL_ROOT_PASSWORD: "a secret mysql root password"
       MYSQL_DATABASE: my_database
@@ -15,21 +15,21 @@ services:
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/mysql8.0:stable
+FROM quay.io/continuouspipe/mysql8.0:latest
 ```
 
 # MySQL 5.7
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/mysql5.7:stable
+FROM quay.io/continuouspipe/mysql5.7:latest
 ```
 In docker-compose.yml:
 ```yml
 version: '3'
 services:
   database:
-    image: quay.io/continuouspipe/mysql5.7:stable
+    image: quay.io/continuouspipe/mysql5.7:latest
     environment:
       MYSQL_ROOT_PASSWORD: "a secret mysql root password"
       MYSQL_DATABASE: my_database
@@ -41,14 +41,14 @@ services:
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/mysql5.6:stable
+FROM quay.io/continuouspipe/mysql5.6:latest
 ```
 In docker-compose.yml:
 ```yml
 version: '3'
 services:
   database:
-    image: quay.io/continuouspipe/mysql5.6:stable
+    image: quay.io/continuouspipe/mysql5.6:latest
     environment:
       MYSQL_ROOT_PASSWORD: "a secret mysql root password"
       MYSQL_DATABASE: my_database

--- a/nginx-reverse-proxy/README.md
+++ b/nginx-reverse-proxy/README.md
@@ -5,7 +5,7 @@ In a docker-compose.yml:
 version: '3'
 services:
   proxy:
-    image: quay.io/continuouspipe/nginx-reverse-proxy:stable
+    image: quay.io/continuouspipe/nginx-reverse-proxy:latest
     depends_on:
      - web
     environment:
@@ -15,7 +15,7 @@ services:
 ```
 
 ```Dockerfile
-FROM quay.io/continuouspipe/nginx-reverse-proxy:stable
+FROM quay.io/continuouspipe/nginx-reverse-proxy:latest
 ```
 
 ## How to build

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -2,7 +2,7 @@
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/nginx:stable
+FROM quay.io/continuouspipe/nginx:latest
 
 COPY . /app
 RUN container build
@@ -13,7 +13,7 @@ In a docker-compose.yml:
 version: '3'
 services:
   web:
-    image: quay.io/continuouspipe/nginx:stable
+    image: quay.io/continuouspipe/nginx:latest
 ```
 
 ## How to build

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -2,7 +2,7 @@
 
 For Node 7.0 in a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/nodejs7:stable
+FROM quay.io/continuouspipe/nodejs7:latest
 
 COPY . /app
 RUN container build
@@ -12,12 +12,12 @@ or in a docker-compose.yml:
 version: '3'
 services:
   node:
-    image: quay.io/continuouspipe/nodejs7:stable
+    image: quay.io/continuouspipe/nodejs7:latest
 ```
 
 For Node 7.0 without extra packages, in a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/nodejs7-small:stable
+FROM quay.io/continuouspipe/nodejs7-small:latest
 
 COPY . /app
 RUN container build
@@ -27,12 +27,12 @@ or in a docker-compose.yml:
 version: '3'
 services:
   node:
-    image: quay.io/continuouspipe/nodejs7-small:stable
+    image: quay.io/continuouspipe/nodejs7-small:latest
 ```
 
 For Node 6.0 in a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/nodejs6:stable
+FROM quay.io/continuouspipe/nodejs6:latest
 
 COPY . /app
 RUN container build
@@ -42,12 +42,12 @@ or in a docker-compose.yml:
 version: '3'
 services:
   node:
-    image: quay.io/continuouspipe/nodejs6:stable
+    image: quay.io/continuouspipe/nodejs6:latest
 ```
 
 For Node 6.0 without extra packages, in a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/nodejs6-small:stable
+FROM quay.io/continuouspipe/nodejs6-small:latest
 
 COPY . /app
 RUN container build
@@ -57,7 +57,7 @@ or in a docker-compose.yml:
 version: '3'
 services:
   node:
-    image: quay.io/continuouspipe/nodejs6-small:stable
+    image: quay.io/continuouspipe/nodejs6-small:latest
 ```
 
 ## How to build

--- a/phantomjs/README.md
+++ b/phantomjs/README.md
@@ -5,12 +5,12 @@ In a docker-compose.yml:
 version: '3'
 services:
   phantomjs:
-    image: quay.io/continuouspipe/phantomjs2:stable
+    image: quay.io/continuouspipe/phantomjs2:latest
 ```
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/phantomjs2:stable
+FROM quay.io/continuouspipe/phantomjs2:latest
 ```
 
 ## How to build

--- a/php/apache/README.md
+++ b/php/apache/README.md
@@ -1,7 +1,7 @@
 # PHP Apache
 For PHP 7.2 in a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/php7.2-apache:stable
+FROM quay.io/continuouspipe/php7.2-apache:latest
 ARG GITHUB_TOKEN=
 
 COPY . /app
@@ -12,12 +12,12 @@ or in a docker-compose.yml:
 version: '3'
 services:
   web:
-    image: quay.io/continuouspipe/php7.2-apache:stable
+    image: quay.io/continuouspipe/php7.2-apache:latest
 ```
 
 For PHP 7.1 in a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/php7.1-apache:stable
+FROM quay.io/continuouspipe/php7.1-apache:latest
 ARG GITHUB_TOKEN=
 
 COPY . /app
@@ -28,12 +28,12 @@ or in a docker-compose.yml:
 version: '3'
 services:
   web:
-    image: quay.io/continuouspipe/php7.1-apache:stable
+    image: quay.io/continuouspipe/php7.1-apache:latest
 ```
 
 For PHP 7.0 in a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/php7-apache:stable
+FROM quay.io/continuouspipe/php7-apache:latest
 ARG GITHUB_TOKEN=
 
 COPY . /app
@@ -44,12 +44,12 @@ or in a docker-compose.yml:
 version: '3'
 services:
   web:
-    image: quay.io/continuouspipe/php7-apache:stable
+    image: quay.io/continuouspipe/php7-apache:latest
 ```
 
 For PHP 5.6 in a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/php5.6-apache:stable
+FROM quay.io/continuouspipe/php5.6-apache:latest
 ARG GITHUB_TOKEN=
 
 COPY . /app
@@ -60,7 +60,7 @@ or in a docker-compose.yml:
 version: '3'
 services:
   web:
-    image: quay.io/continuouspipe/php5.6-apache:stable
+    image: quay.io/continuouspipe/php5.6-apache:latest
 ```
 
 ## How to build

--- a/php/nginx/README.md
+++ b/php/nginx/README.md
@@ -2,7 +2,7 @@
 
 For PHP 7.2 in a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/php7.2-nginx:stable
+FROM quay.io/continuouspipe/php7.2-nginx:latest
 ARG GITHUB_TOKEN=
 
 COPY . /app
@@ -13,12 +13,12 @@ or in a docker-compose.yml:
 version: '3'
 services:
   web:
-    image: quay.io/continuouspipe/php7.2-nginx:stable
+    image: quay.io/continuouspipe/php7.2-nginx:latest
 ```
 
 For PHP 7.1 in a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/php7.1-nginx:stable
+FROM quay.io/continuouspipe/php7.1-nginx:latest
 ARG GITHUB_TOKEN=
 
 COPY . /app
@@ -29,12 +29,12 @@ or in a docker-compose.yml:
 version: '3'
 services:
   web:
-    image: quay.io/continuouspipe/php7.1-nginx:stable
+    image: quay.io/continuouspipe/php7.1-nginx:latest
 ```
 
 For PHP 7.0 in a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/php7-nginx:stable
+FROM quay.io/continuouspipe/php7-nginx:latest
 ARG GITHUB_TOKEN=
 
 COPY . /app
@@ -45,12 +45,12 @@ or in a docker-compose.yml:
 version: '3'
 services:
   web:
-    image: quay.io/continuouspipe/php7-nginx:stable
+    image: quay.io/continuouspipe/php7-nginx:latest
 ```
 
 For PHP 5.6 in a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/php5.6-nginx:stable
+FROM quay.io/continuouspipe/php5.6-nginx:latest
 ARG GITHUB_TOKEN=
 
 COPY . /app
@@ -61,7 +61,7 @@ or in a docker-compose.yml:
 version: '3'
 services:
   web:
-    image: quay.io/continuouspipe/php5.6-nginx:stable
+    image: quay.io/continuouspipe/php5.6-nginx:latest
 ```
 
 ## How to build

--- a/piwik/README.md
+++ b/piwik/README.md
@@ -5,12 +5,12 @@ In a docker-compose.yml:
 version: '3'
 services:
   piwik:
-    image: quay.io/continuouspipe/piwik-php7.1-apache:stable
+    image: quay.io/continuouspipe/piwik-php7.1-apache:latest
 ```
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/piwik-php7.1-apache:stable
+FROM quay.io/continuouspipe/piwik-php7.1-apache:latest
 ```
 
 ## How to build

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -5,7 +5,7 @@ For Postgres 9.6 in a docker-compose.yml:
 version: '3'
 services:
   database:
-    image: quay.io/continuouspipe/postgres9.6:stable
+    image: quay.io/continuouspipe/postgres9.6:latest
     expose:
       - 5432
     environment:
@@ -18,7 +18,7 @@ services:
 
 or in a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/postgres9.6:stable
+FROM quay.io/continuouspipe/postgres9.6:latest
 ```
 
 For Postgres 9.4 in a docker-compose.yml:
@@ -26,7 +26,7 @@ For Postgres 9.4 in a docker-compose.yml:
 version: '3'
 services:
   database:
-    image: quay.io/continuouspipe/postgres9.4:stable
+    image: quay.io/continuouspipe/postgres9.4:latest
     expose:
       - 5432
     environment:
@@ -39,7 +39,7 @@ services:
 
 or in a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/postgres9.4:stable
+FROM quay.io/continuouspipe/postgres9.4:latest
 ```
 
 ## How to build

--- a/rabbitmq/README.md
+++ b/rabbitmq/README.md
@@ -6,8 +6,8 @@ Includes the management plugin which is available on the port `15672`
 version: '3'
 services:
   rabbitmq:
-    image: "quay.io/continuouspipe/rabbitmq37-management:stable"
-    # image: "quay.io/continuouspipe/rabbitmq36-management:stable"
+    image: "quay.io/continuouspipe/rabbitmq37-management:latest"
+    # image: "quay.io/continuouspipe/rabbitmq36-management:latest"
     hostname: "rabbitmq"
     environment:
       RABBITMQ_ERLANG_COOKIE: "SAMPLE"
@@ -22,9 +22,9 @@ services:
 ```
 ### Dockerfile
 ```
-FROM quay.io/continuouspipe/rabbitmq37-management:stable
+FROM quay.io/continuouspipe/rabbitmq37-management:latest
 ```
 or
 ```
-FROM quay.io/continuouspipe/rabbitmq36-management:stable
+FROM quay.io/continuouspipe/rabbitmq36-management:latest
 ```

--- a/redis/3.2/README.md
+++ b/redis/3.2/README.md
@@ -5,12 +5,12 @@ In a docker-compose.yml:
 version: '3'
 services:
   redis:
-    image: quay.io/continuouspipe/redis3:stable
+    image: quay.io/continuouspipe/redis3:latest
 ```
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/redis3:stable
+FROM quay.io/continuouspipe/redis3:latest
 ```
 
 ## How to build

--- a/scala-base/1.0/README.md
+++ b/scala-base/1.0/README.md
@@ -5,12 +5,12 @@ In a docker-compose.yml:
 version: '3'
 services:
   scala:
-    image: quay.io/continuouspipe/scala-base:stable
+    image: quay.io/continuouspipe/scala-base:latest
 ```
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/scala-base:stable
+FROM quay.io/continuouspipe/scala-base:latest
 ```
 
 ## How to build

--- a/solr/4.10/README.md
+++ b/solr/4.10/README.md
@@ -5,7 +5,7 @@ In a docker-compose.yml:
 version: '3'
 services:
   solr:
-    image: quay.io/continuouspipe/solr4:stable
+    image: quay.io/continuouspipe/solr4:latest
     environment:
       SOLR_CORE_NAME: example_core
     volumes:
@@ -22,7 +22,7 @@ volumes:
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/solr4:stable
+FROM quay.io/continuouspipe/solr4:latest
 ```
 
 ## How to build

--- a/solr/6.2/README.md
+++ b/solr/6.2/README.md
@@ -5,7 +5,7 @@ In a docker-compose.yml:
 version: '3'
 services:
   solr:
-    image: quay.io/continuouspipe/solr6:stable
+    image: quay.io/continuouspipe/solr6:latest
     environment:
       SOLR_CORE_NAME: example_core
     volumes:
@@ -22,7 +22,7 @@ volumes:
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/solr6:stable
+FROM quay.io/continuouspipe/solr6:latest
 ```
 
 ## How to build

--- a/spryker/README.md
+++ b/spryker/README.md
@@ -3,7 +3,7 @@
 In a Dockerfile for PHP and NGINX:
 ```Dockerfile
 ARG PHP_IMAGE_VERSION=7.3 # 7.1 and 7.2 are also available.
-FROM quay.io/continuouspipe/spryker-php${PHP_IMAGE_VERSION}-nginx:stable
+FROM quay.io/continuouspipe/spryker-php${PHP_IMAGE_VERSION}-nginx:latest
 
 ARG IMAGE_VERSION=2
 ARG GITHUB_TOKEN=
@@ -16,7 +16,7 @@ RUN container build
 In a Dockerfile for PHP and Apache:
 ```Dockerfile
 ARG PHP_VERSION=7.3 # 7.1 and 7.2 are also available.
-FROM quay.io/continuouspipe/spryker-php${PHP_VERSION}-apache:stable
+FROM quay.io/continuouspipe/spryker-php${PHP_VERSION}-apache:latest
 
 ARG IMAGE_VERSION=2
 ARG GITHUB_TOKEN=

--- a/ssh-forward/README.md
+++ b/ssh-forward/README.md
@@ -5,7 +5,7 @@ In a docker-compose.yml:
 version: '3'
 services:
   sshforward:
-    image: quay.io/continuouspipe/ssh-forward:stable
+    image: quay.io/continuouspipe/ssh-forward:latest
     environment:
       SSH_FORWARD_PASSWORD: forward
       SSH_AUTHORIZED_KEYS: "ssh-rsa AAA..."
@@ -13,7 +13,7 @@ services:
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/ssh-forward:stable
+FROM quay.io/continuouspipe/ssh-forward:latest
 ```
 
 ## How to build

--- a/symfony/README.md
+++ b/symfony/README.md
@@ -67,7 +67,7 @@ var/cache/**
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/symfony-php7.2-nginx:stable
+FROM quay.io/continuouspipe/symfony-php7.2-nginx:latest
 ARG GITHUB_TOKEN=
 ARG SYMFONY_ENV=prod
 
@@ -76,7 +76,7 @@ RUN container build
 ```
 
 ```Dockerfile
-FROM quay.io/continuouspipe/symfony-php7.1-nginx:stable
+FROM quay.io/continuouspipe/symfony-php7.1-nginx:latest
 ARG GITHUB_TOKEN=
 ARG SYMFONY_ENV=prod
 
@@ -85,7 +85,7 @@ RUN container build
 ```
 
 ```Dockerfile
-FROM quay.io/continuouspipe/symfony-php7-nginx:stable
+FROM quay.io/continuouspipe/symfony-php7-nginx:latest
 ARG GITHUB_TOKEN=
 ARG SYMFONY_ENV=prod
 
@@ -94,7 +94,7 @@ RUN container build
 ```
 
 ```Dockerfile
-FROM quay.io/continuouspipe/symfony-php5.6-nginx:stable
+FROM quay.io/continuouspipe/symfony-php5.6-nginx:latest
 ARG GITHUB_TOKEN=
 ARG SYMFONY_ENV=prod
 
@@ -106,7 +106,7 @@ RUN container build
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/symfony-php7.2-apache:stable
+FROM quay.io/continuouspipe/symfony-php7.2-apache:latest
 ARG GITHUB_TOKEN=
 ARG SYMFONY_ENV=prod
 
@@ -115,7 +115,7 @@ RUN container build
 ```
 
 ```Dockerfile
-FROM quay.io/continuouspipe/symfony-php7.1-apache:stable
+FROM quay.io/continuouspipe/symfony-php7.1-apache:latest
 ARG GITHUB_TOKEN=
 ARG SYMFONY_ENV=prod
 
@@ -124,7 +124,7 @@ RUN container build
 ```
 
 ```Dockerfile
-FROM quay.io/continuouspipe/symfony-php7-apache:stable
+FROM quay.io/continuouspipe/symfony-php7-apache:latest
 ARG GITHUB_TOKEN=
 ARG SYMFONY_ENV=prod
 
@@ -133,7 +133,7 @@ RUN container build
 ```
 
 ```Dockerfile
-FROM quay.io/continuouspipe/symfony-php5.6-apache:stable
+FROM quay.io/continuouspipe/symfony-php5.6-apache:latest
 ARG GITHUB_TOKEN=
 ARG SYMFONY_ENV=prod
 

--- a/tideways/README.md
+++ b/tideways/README.md
@@ -2,19 +2,19 @@
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/tideways:stable
+FROM quay.io/continuouspipe/tideways:latest
 ```
 or in a docker-compose.yml:
 ```yml
 version: '3'
 services:
   web:
-    image: quay.io/continuouspipe/php7.1-nginx:stable
+    image: quay.io/continuouspipe/php7.1-nginx:latest
     links:
       - tideways
 
   tideways:
-    image: quay.io/continuouspipe/tideways:stable
+    image: quay.io/continuouspipe/tideways:latest
 ```
 
 ## How to build

--- a/tools/compare/README.md
+++ b/tools/compare/README.md
@@ -1,7 +1,7 @@
 # Comparison Tool
 
-A tool to compare the :latest and :stable tags of each of the docker images, and tag
-the :latest image as :stable if the diff is agreeable.
+A tool to compare the :latest and :latest tags of each of the docker images, and tag
+the :latest image as :latest if the diff is agreeable.
 
 ## Usage
 

--- a/ubuntu/16.04/README.md
+++ b/ubuntu/16.04/README.md
@@ -2,7 +2,7 @@
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/ubuntu16.04:stable
+FROM quay.io/continuouspipe/ubuntu16.04:latest
 
 COPY ./somedir /somedir
 
@@ -14,12 +14,12 @@ In a docker-compose.yml:
 version: '3'
 services:
   ubuntu:
-    image: quay.io/continuouspipe/ubuntu16.04:stable
+    image: quay.io/continuouspipe/ubuntu16.04:latest
 ```
 
 ## How to build
 ```bash
-docker build --pull --tag quay.io/continuouspipe/ubuntu16.04:stable --rm .
+docker build --pull --tag quay.io/continuouspipe/ubuntu16.04:latest --rm .
 docker push
 ```
 

--- a/varnish/4.0/README.md
+++ b/varnish/4.0/README.md
@@ -5,14 +5,14 @@ In a docker-compose.yml:
 version: '3'
 services:
   varnish:
-    image: quay.io/continuouspipe/varnish4:stable
+    image: quay.io/continuouspipe/varnish4:latest
     environment:
       VARNISH_SECRET: "A secret that should remain secret!"
 ```
 
 In a Dockerfile:
 ```Dockerfile
-FROM quay.io/continuouspipe/varnish4:stable
+FROM quay.io/continuouspipe/varnish4:latest
 ```
 
 


### PR DESCRIPTION
Testing `latest` and tagging `stable` is too much of a maintenance overhead.
Advise to use :latest image as it is built nightly by Travis.