### PR TITLE
php-fpm running on Heroku

### DIFF
--- a/php/nginx/etc/confd/templates/supervisor/php-fpm.conf.tmpl
+++ b/php/nginx/etc/confd/templates/supervisor/php-fpm.conf.tmpl
@@ -17,7 +17,9 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+{{ if not (eq "true" (getenv "NON_PRIVILEGED_USER")) }}
 user = {{ getenv "APP_USER" }}
+{{ end }}
 autostart = {{ getenv "START_PHP_FPM" }}
 autorestart = true
 priority = 5


### PR DESCRIPTION
Because of this `user=`, supervisor tries to change the permissions of the running process (https://github.com/Supervisor/supervisor/issues/695), which you can't on Heroku for instance.